### PR TITLE
Add other Meridio resources to be managed by operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,10 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM ubuntu:20.10
 WORKDIR /
 COPY --from=builder /workspace/manager .
+COPY deployment/ deployment/
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,9 @@ docker-build: test ## Build docker image with the manager.
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
 
+kind-load: ## Load docker image to kind cluster
+	kind load docker-image ${IMG}
+
 ##@ Deployment
 
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: localhost:5000/meridio/meridio-operator
-  newTag: v0.0.1
+  newName: controller
+  newTag: latest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,12 +24,29 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+      volumes:
+      - name: templates-volume
+        emptyDir:
+          medium: Memory
+      initContainers:
+      - name: copy
+        image: controller:latest
+        imagePullPolicy: IfNotPresent
+        command:
+        - cp
+        - -r
+        - ./deployment/.
+        - ./templates-tmp
+        volumeMounts:
+        - name: templates-volume
+          mountPath: /templates-tmp
       containers:
       - command:
         - /manager
         args:
         - --leader-elect
         image: controller:latest
+        imagePullPolicy: IfNotPresent
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
@@ -52,5 +69,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        volumeMounts:
+        - mountPath: /deployment
+          name: templates-volume
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,9 +7,33 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - ""
   resources:
   - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
   verbs:
   - create
   - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,6 +9,18 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - daemonsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
   - deployments
   verbs:
   - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -33,6 +33,18 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - create
@@ -68,3 +80,27 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/controllers/reconciler/action.go
+++ b/controllers/reconciler/action.go
@@ -1,0 +1,111 @@
+package reconciler
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
+	"golang.org/x/net/context"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type Executions interface {
+	create(obj client.Object) error
+	update(obj client.Object) error
+	delete(obj client.Object) error
+	RunAll(actions []Action) error
+}
+
+type Action interface {
+	Run(e *Executor) (string, error)
+}
+
+type Executor struct {
+	scheme *runtime.Scheme
+	client client.Client
+	ctx    context.Context
+	cr     *meridiov1alpha1.Trench
+	log    logr.Logger
+}
+
+func NewExecutor(s *runtime.Scheme, c client.Client, ct context.Context, cr *meridiov1alpha1.Trench) *Executor {
+	return &Executor{
+		scheme: s,
+		client: c,
+		ctx:    ct,
+		cr:     cr,
+		log:    log.Log.WithName("reconciler"),
+	}
+}
+
+func (e *Executor) runAll(actions []Action) error {
+	for _, action := range actions {
+		msg, err := action.Run(e)
+		if err != nil {
+			e.log.Error(err, msg, "result", "failure")
+			return err
+		}
+		e.log.Info(msg, "result", "succeess")
+	}
+	return nil
+}
+
+type createAction struct {
+	obj client.Object
+	msg string
+}
+
+type updateAction struct {
+	obj client.Object
+	msg string
+}
+
+func (a createAction) Run(e *Executor) (string, error) {
+	return a.msg, e.create(a.obj)
+}
+
+func (a updateAction) Run(e *Executor) (string, error) {
+	return a.msg, e.update(a.obj)
+}
+
+func (e *Executor) create(obj client.Object) error {
+	err := controllerutil.SetControllerReference(e.cr, obj, e.scheme)
+	if err != nil {
+		return fmt.Errorf("set reference error: %s", err)
+	}
+
+	return e.client.Create(e.ctx, obj)
+}
+
+func (e *Executor) update(obj client.Object) error {
+	err := controllerutil.SetControllerReference(e.cr, obj, e.scheme)
+	if err != nil {
+		return fmt.Errorf("set reference error: %s", err)
+	}
+
+	err = e.client.Update(e.ctx, obj)
+	if err != nil {
+		// conflicts will happen when there are frequent actions
+		if errors.IsConflict(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func (e *Executor) delete(obj client.Object) error {
+	return e.client.Delete(e.ctx, obj)
+}
+
+func newCreateAction(obj client.Object, msg string) Action {
+	return createAction{obj: obj, msg: msg}
+}
+
+func newUpdateAction(obj client.Object, msg string) Action {
+	return updateAction{obj: obj, msg: msg}
+}

--- a/controllers/reconciler/configmap.go
+++ b/controllers/reconciler/configmap.go
@@ -1,0 +1,141 @@
+package reconciler
+
+import (
+	"fmt"
+
+	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
+	"golang.org/x/net/context"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	MeridioConfigKey = "meridio.conf"
+)
+
+type Config struct {
+	VIPs []string `yaml:"vips"`
+}
+
+type ConfigMap struct {
+	currentStatus *corev1.ConfigMap
+	desiredStatus *corev1.ConfigMap
+}
+
+func diffConfigmap(cc *corev1.ConfigMap, cr *meridiov1alpha1.Trench) (bool, string) {
+	cd, ok := cc.Data[MeridioConfigKey]
+	if !ok {
+		return true, "Meridio config key not found"
+	}
+	config := &Config{}
+	err := yaml.Unmarshal([]byte(cd), &config)
+	if err != nil {
+		return true, "Unmarshal error"
+	}
+	if !vipListsEqual(config.VIPs, cr.Spec.VIPs) {
+		return true, fmt.Sprintf("Different VIPs. Current: %v. Desired: %v", config.VIPs, cr.Spec.VIPs)
+	}
+	return false, ""
+}
+
+func vipListsEqual(vipListA, vipListB []string) bool {
+	vipsA := make(map[string]struct{})
+	vipsB := make(map[string]struct{})
+	for _, vip := range vipListA {
+		vipsA[vip] = struct{}{}
+	}
+	for _, vip := range vipListB {
+		vipsB[vip] = struct{}{}
+	}
+	for _, vip := range vipListA {
+		if _, ok := vipsB[vip]; !ok {
+			return false
+		}
+	}
+	for _, vip := range vipListB {
+		if _, ok := vipsA[vip]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (c *ConfigMap) getData(trench *meridiov1alpha1.Trench) (string, error) {
+	config := &Config{
+		VIPs: trench.Spec.VIPs,
+	}
+	configYAML, err := yaml.Marshal(&config)
+	if err != nil {
+		return "", fmt.Errorf("error yaml.Marshal: %s", err)
+	}
+	return string(configYAML), nil
+}
+
+func (c *ConfigMap) getSelector(cr *meridiov1alpha1.Trench) client.ObjectKey {
+	return client.ObjectKey{
+		Namespace: cr.ObjectMeta.Namespace,
+		Name:      cr.Spec.ConfigMapName,
+	}
+}
+
+func (c *ConfigMap) getCurrentStatus(ctx context.Context, cr *meridiov1alpha1.Trench, client client.Client) error {
+	currentState := &corev1.ConfigMap{}
+	err := client.Get(ctx, c.getSelector(cr), currentState)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	c.currentStatus = currentState.DeepCopy()
+	return nil
+}
+
+func (c *ConfigMap) insertParamters(cc *corev1.ConfigMap, cr *meridiov1alpha1.Trench) (*corev1.ConfigMap, error) {
+	cc.ObjectMeta.Name = cr.Spec.ConfigMapName
+	cc.ObjectMeta.Namespace = cr.ObjectMeta.Namespace
+	data, err := c.getData(cr)
+	if err != nil {
+		return nil, err
+	}
+	cc.Data = map[string]string{
+		MeridioConfigKey: data,
+	}
+	return cc, nil
+}
+
+func (c *ConfigMap) getDesiredStatus(cr *meridiov1alpha1.Trench) error {
+	configmap := &corev1.ConfigMap{}
+	var err error
+	configmap, err = c.insertParamters(configmap, cr)
+	if err != nil {
+		return err
+	}
+	c.desiredStatus = configmap
+	return nil
+}
+
+func (c *ConfigMap) getAction(e *Executor, cr *meridiov1alpha1.Trench) (Action, error) {
+	var action Action
+	err := c.getCurrentStatus(e.ctx, cr, e.client)
+	if err != nil {
+		return action, err
+	}
+	if c.currentStatus == nil {
+		err = c.getDesiredStatus(cr)
+		if err != nil {
+			return action, err
+		}
+		e.log.Info("configmap", "add action", "create")
+		action = newCreateAction(c.desiredStatus, "create configmap")
+	} else {
+		if diff, msg := diffConfigmap(c.currentStatus, cr); diff {
+			e.log.Info("configmap", "add action", "update")
+			action = newUpdateAction(c.desiredStatus, fmt.Sprintf("update configmap, %s", msg))
+		}
+	}
+	return action, nil
+}

--- a/controllers/reconciler/ipam-service.go
+++ b/controllers/reconciler/ipam-service.go
@@ -1,0 +1,104 @@
+package reconciler
+
+import (
+	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
+	"golang.org/x/net/context"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	ipamPort       = 7777
+	ipamTargetPort = 7777
+	ipamSvcName    = "ipam-service"
+)
+
+type IpamService struct {
+	currentStatus *corev1.Service
+	desiredStatus *corev1.Service
+}
+
+func (i *IpamService) getPorts(cr *meridiov1alpha1.Trench) []corev1.ServicePort {
+	// if ipam service ports are set in the cr, use the values
+	// else return default service ports
+	return []corev1.ServicePort{
+		{
+			Protocol:   corev1.ProtocolTCP,
+			TargetPort: intstr.FromInt(ipamTargetPort),
+			Port:       ipamPort,
+		},
+	}
+}
+func (i *IpamService) getSelector(cr *meridiov1alpha1.Trench) client.ObjectKey {
+	return client.ObjectKey{
+		Namespace: cr.ObjectMeta.Namespace,
+		Name:      ipamSvcName,
+	}
+}
+
+func (i *IpamService) insertParamters(svc *corev1.Service, cr *meridiov1alpha1.Trench) *corev1.Service {
+	// if status ipam service parameters are specified in the cr, use those
+	// else use the default parameters
+	svc.ObjectMeta.Namespace = cr.ObjectMeta.Namespace
+	svc.Spec.Ports = i.getPorts(cr)
+	return svc
+}
+
+func (i *IpamService) getCurrentStatus(ctx context.Context, cr *meridiov1alpha1.Trench, client client.Client) error {
+	currentStatus := &corev1.Service{}
+	selector := i.getSelector(cr)
+	err := client.Get(ctx, selector, currentStatus)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	i.currentStatus = currentStatus.DeepCopy()
+	return nil
+}
+
+func (i *IpamService) getDesiredStatus(cr *meridiov1alpha1.Trench) error {
+	ipams, err := i.getModel()
+	if err != nil {
+		return err
+	}
+	i.desiredStatus = i.insertParamters(ipams, cr)
+	return nil
+}
+
+// getReconciledDesiredStatus gets the desired status of ipam service after it's created
+// more paramters than what are defined in the model could be added by K8S
+func (i *IpamService) getReconciledDesiredStatus(ipams *corev1.Service, cr *meridiov1alpha1.Trench) {
+	i.desiredStatus = i.insertParamters(ipams, cr)
+}
+
+func (i *IpamService) getModel() (*corev1.Service, error) {
+	return getServiceModel("deployment/ipam-service.yaml")
+}
+
+func (i *IpamService) getAction(e *Executor, cr *meridiov1alpha1.Trench) (Action, error) {
+	var action Action
+	err := i.getCurrentStatus(e.ctx, cr, e.client)
+	if err != nil {
+		return nil, err
+	}
+	if i.currentStatus == nil {
+		err = i.getDesiredStatus(cr)
+		if err != nil {
+			return nil, err
+		}
+		e.log.Info("ipam service", "add action", "create")
+		action = newCreateAction(i.desiredStatus, "create ipam service")
+	} else {
+		i.getReconciledDesiredStatus(i.currentStatus, cr)
+		if !equality.Semantic.DeepEqual(i.desiredStatus, i.currentStatus) {
+			e.log.Info("ipam service", "add action", "update")
+			action = newUpdateAction(i.desiredStatus, "update ipam service")
+		}
+	}
+	return action, nil
+}

--- a/controllers/reconciler/ipam.go
+++ b/controllers/reconciler/ipam.go
@@ -1,0 +1,110 @@
+package reconciler
+
+import (
+	"fmt"
+
+	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
+	"golang.org/x/net/context"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	imageIpam   = "ipam"
+	ipamEnvName = "IPAM_PORT"
+)
+
+type IpamDeployment struct {
+	currentStatus *appsv1.Deployment
+	desiredStatus *appsv1.Deployment
+}
+
+func (i *IpamDeployment) getEnvVars(cr *meridiov1alpha1.Trench) []corev1.EnvVar {
+	// if envVars are set in the cr, use the values
+	// else return default envVars
+	return []corev1.EnvVar{
+		{
+			Name:  ipamEnvName,
+			Value: fmt.Sprint(ipamTargetPort),
+		},
+	}
+}
+
+func (i *IpamDeployment) insertParamters(dep *appsv1.Deployment, cr *meridiov1alpha1.Trench) *appsv1.Deployment {
+	// if status ipam deployment parameters are specified in the cr, use those
+	// else use the default parameters
+	dep.ObjectMeta.Namespace = cr.ObjectMeta.Namespace
+	dep.Spec.Template.Spec.Containers[0].Image = fmt.Sprintf("%s/%s/%s:%s", Registry, Organization, imageIpam, Tag)
+	dep.Spec.Template.Spec.Containers[0].ImagePullPolicy = PullPolicy
+	dep.Spec.Template.Spec.Containers[0].LivenessProbe = GetLivenessProbe(cr)
+	dep.Spec.Template.Spec.Containers[0].ReadinessProbe = GetReadinessProbe(cr)
+	dep.Spec.Template.Spec.Containers[0].Env = i.getEnvVars(cr)
+	return dep
+}
+
+func (i *IpamDeployment) getModel() (*appsv1.Deployment, error) {
+	return getDeploymentModel("deployment/ipam.yaml")
+}
+
+func (i *IpamDeployment) getSelector(cr *meridiov1alpha1.Trench) client.ObjectKey {
+	return client.ObjectKey{
+		Namespace: cr.ObjectMeta.Namespace,
+		Name:      "ipam",
+	}
+}
+
+func (i *IpamDeployment) getDesiredStatus(cr *meridiov1alpha1.Trench) error {
+	ipamDeployment, err := i.getModel()
+	if err != nil {
+		return err
+	}
+	i.desiredStatus = i.insertParamters(ipamDeployment, cr)
+	return nil
+}
+
+// getIpamDeploymentReconciledDesiredStatus gets the desired status of ipam deployment after it's created
+// more paramters than what are defined in the model could be added by K8S
+func (i *IpamDeployment) getReconciledDesiredStatus(cd *appsv1.Deployment, cr *meridiov1alpha1.Trench) {
+	i.desiredStatus = i.insertParamters(cd, cr)
+}
+
+func (i *IpamDeployment) getCurrentStatus(ctx context.Context, cr *meridiov1alpha1.Trench, client client.Client) error {
+	currentStatus := &appsv1.Deployment{}
+	selector := i.getSelector(cr)
+	err := client.Get(ctx, selector, currentStatus)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	i.currentStatus = currentStatus.DeepCopy()
+	return nil
+}
+
+func (i *IpamDeployment) getAction(e *Executor, cr *meridiov1alpha1.Trench) (Action, error) {
+	var action Action
+	err := i.getCurrentStatus(e.ctx, cr, e.client)
+	if err != nil {
+		return nil, err
+	}
+	if i.currentStatus == nil {
+		err = i.getDesiredStatus(cr)
+		if err != nil {
+			return nil, err
+		}
+		e.log.Info("ipam deployment", "add action", "create")
+		action = newCreateAction(i.desiredStatus, "create ipam deployment")
+	} else {
+		i.getReconciledDesiredStatus(i.currentStatus, cr)
+		if !equality.Semantic.DeepEqual(i.desiredStatus, i.currentStatus) {
+
+			e.log.Info("ipam deployment", "add action", "update")
+			action = newUpdateAction(i.desiredStatus, "update ipam deployment")
+		}
+	}
+	return action, nil
+}

--- a/controllers/reconciler/load-balancer.go
+++ b/controllers/reconciler/load-balancer.go
@@ -1,0 +1,95 @@
+package reconciler
+
+import (
+	"fmt"
+
+	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
+	"golang.org/x/net/context"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	lbImage = "load-balancer"
+)
+
+type LoadBalancer struct {
+	currentStatus *appsv1.Deployment
+	desiredStatus *appsv1.Deployment
+}
+
+func (l *LoadBalancer) getModel() (*appsv1.Deployment, error) {
+	return getDeploymentModel("deployment/load-balancer.yaml")
+}
+
+func (l *LoadBalancer) insertParamters(dep *appsv1.Deployment, cr *meridiov1alpha1.Trench) *appsv1.Deployment {
+	// if status load-balancer deployment parameters are specified in the cr, use those
+	// else use the default parameters
+	dep.ObjectMeta.Namespace = cr.ObjectMeta.Namespace
+	dep.Spec.Template.Spec.Containers[0].Image = fmt.Sprintf("%s/%s/%s:%s", Registry, Organization, lbImage, Tag)
+	dep.Spec.Template.Spec.Containers[0].ImagePullPolicy = PullPolicy
+	dep.Spec.Template.Spec.Containers[0].LivenessProbe = GetLivenessProbe(cr)
+	dep.Spec.Template.Spec.Containers[0].ReadinessProbe = GetReadinessProbe(cr)
+	return dep
+}
+
+func (l *LoadBalancer) getSelector(cr *meridiov1alpha1.Trench) client.ObjectKey {
+	return client.ObjectKey{
+		Namespace: cr.ObjectMeta.Namespace,
+		Name:      "load-balancer",
+	}
+}
+
+func (l *LoadBalancer) getCurrentStatus(ctx context.Context, cr *meridiov1alpha1.Trench, client client.Client) error {
+	currentState := &appsv1.Deployment{}
+	err := client.Get(ctx, l.getSelector(cr), currentState)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	l.currentStatus = currentState.DeepCopy()
+	return nil
+}
+
+func (l *LoadBalancer) getDesiredStatus(cr *meridiov1alpha1.Trench) error {
+	dep, err := l.getModel()
+	if err != nil {
+		return err
+	}
+	l.desiredStatus = l.insertParamters(dep, cr)
+	return nil
+}
+
+// getReconciledDesiredStatus gets the desired status of load-balancer deployment after it's created
+// more paramters than what are defined in the model could be added by K8S
+func (i *LoadBalancer) getReconciledDesiredStatus(lb *appsv1.Deployment, cr *meridiov1alpha1.Trench) {
+	lb = i.insertParamters(lb, cr)
+	i.desiredStatus = lb
+}
+
+func (l *LoadBalancer) getAction(e *Executor, cr *meridiov1alpha1.Trench) (Action, error) {
+	var action Action
+	err := l.getCurrentStatus(e.ctx, cr, e.client)
+	if err != nil {
+		return nil, err
+	}
+	if l.currentStatus == nil {
+		err = l.getDesiredStatus(cr)
+		if err != nil {
+			return nil, err
+		}
+		e.log.Info("load-balancer", "add action", "create")
+		action = newCreateAction(l.desiredStatus, "create load-balncer deployment")
+	} else {
+		l.getReconciledDesiredStatus(l.currentStatus, cr)
+		if !equality.Semantic.DeepEqual(l.desiredStatus, l.currentStatus) {
+			e.log.Info("load-balancer", "add action", "update")
+			action = newUpdateAction(l.desiredStatus, "update load-balncer deployment")
+		}
+	}
+	return action, nil
+}

--- a/controllers/reconciler/models.go
+++ b/controllers/reconciler/models.go
@@ -1,0 +1,76 @@
+package reconciler
+
+import (
+	"fmt"
+	"os"
+
+	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+const (
+	Registry     = "registry.nordix.org"
+	Organization = "cloud-native/meridio"
+	Tag          = "latest"
+	PullPolicy   = "IfNotPresent"
+)
+
+func GetReadinessProbe(cr *meridiov1alpha1.Trench) *corev1.Probe {
+	// if readiness probe is set in the cr do something
+	// else use the default readiness probe
+	return &corev1.Probe{
+		Handler: corev1.Handler{
+			Exec: &corev1.ExecAction{
+				Command: []string{"/bin/grpc_health_probe", "-addr=:8000", "-connect-timeout=100ms", "-rpc-timeout=150ms"},
+			},
+		},
+		InitialDelaySeconds: 0,
+		PeriodSeconds:       10,
+		TimeoutSeconds:      3,
+		FailureThreshold:    5,
+	}
+}
+
+func GetLivenessProbe(cr *meridiov1alpha1.Trench) *corev1.Probe {
+	// if liveness probe is set in the cr do something
+	// else use the default liveness probe
+	return &corev1.Probe{
+		Handler: corev1.Handler{
+			Exec: &corev1.ExecAction{
+				Command: []string{"/bin/grpc_health_probe", "-addr=:8000", "-connect-timeout=100ms", "-rpc-timeout=150ms"},
+			},
+		},
+		InitialDelaySeconds: 0,
+		PeriodSeconds:       10,
+		TimeoutSeconds:      3,
+		FailureThreshold:    5,
+	}
+}
+
+func getDeploymentModel(f string) (*appsv1.Deployment, error) {
+	data, err := os.Open(f)
+	if err != nil {
+		return nil, fmt.Errorf("open %s error: %s", f, err)
+	}
+	deployment := &appsv1.Deployment{}
+	err = yaml.NewYAMLOrJSONDecoder(data, 4096).Decode(deployment)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s error: %s", f, err)
+	}
+	return deployment, nil
+}
+
+func getServiceModel(f string) (*corev1.Service, error) {
+	data, err := os.Open(f)
+	if err != nil {
+		return nil, fmt.Errorf("open %s error: %s", f, err)
+	}
+	service := &corev1.Service{}
+	err = yaml.NewYAMLOrJSONDecoder(data, 4096).Decode(service)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s error: %s", f, err)
+	}
+	return service, nil
+}

--- a/controllers/reconciler/models.go
+++ b/controllers/reconciler/models.go
@@ -13,12 +13,13 @@ import (
 )
 
 const (
-	Registry     = "registry.nordix.org"
-	Organization = "cloud-native/meridio"
-	Tag          = "latest"
-	PullPolicy   = "IfNotPresent"
-	busyboxImage = "busybox"
-	busyboxTag   = "1.29"
+	Registry        = "registry.nordix.org"
+	Organization    = "cloud-native/meridio"
+	OrganizationNsm = "cloud-native/nsm"
+	Tag             = "latest"
+	PullPolicy      = "IfNotPresent"
+	busyboxImage    = "busybox"
+	busyboxTag      = "1.29"
 
 	IPv4      ipFamily = "ipv4"
 	IPv6      ipFamily = "ipv6"
@@ -34,6 +35,10 @@ const (
 	proxyNetworkService = "proxy.load-balancer"
 	lbNetworkService    = "load-balancer"
 	vlanNetworkService  = "external-vlan"
+	vlanItf             = "eth0"
+	vlanID              = "100"
+	vlanPrefixV4        = "169.254.100.0/24"
+	vlanPrefixV6        = "100:100::/64"
 )
 
 type ipFamily string
@@ -72,6 +77,10 @@ func getPrefixLength(cr *meridiov1alpha1.Trench) string {
 		return fmt.Sprintf("%s,%s", prefixLengthIpv4, prefixLengthIpv4)
 	}
 	return ""
+}
+
+func getVlanNsName(cr *meridiov1alpha1.Trench) string {
+	return fmt.Sprintf("%s.%s", vlanNetworkService, cr.ObjectMeta.Namespace)
 }
 
 func GetReadinessProbe(cr *meridiov1alpha1.Trench) *corev1.Probe {

--- a/controllers/reconciler/models.go
+++ b/controllers/reconciler/models.go
@@ -7,6 +7,8 @@ import (
 	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
@@ -73,4 +75,30 @@ func getServiceModel(f string) (*corev1.Service, error) {
 		return nil, fmt.Errorf("decode %s error: %s", f, err)
 	}
 	return service, nil
+}
+
+func getRoleModel(f string) (*rbacv1.Role, error) {
+	data, err := os.Open(f)
+	if err != nil {
+		return nil, fmt.Errorf("open %s error: %s", f, err)
+	}
+	role := &rbacv1.Role{}
+	err = yaml.NewYAMLOrJSONDecoder(data, 4096).Decode(role)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s error: %s", f, err)
+	}
+	return role, nil
+}
+
+func getRoleBindingModel(f string) (*rbacv1.RoleBinding, error) {
+	data, err := os.Open(f)
+	if err != nil {
+		return nil, fmt.Errorf("open %s error: %s", f, err)
+	}
+	rb := &rbacv1.RoleBinding{}
+	err = yaml.NewYAMLOrJSONDecoder(data, 4096).Decode(rb)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s error: %s", f, err)
+	}
+	return rb, nil
 }

--- a/controllers/reconciler/nse-vlan.go
+++ b/controllers/reconciler/nse-vlan.go
@@ -1,0 +1,139 @@
+package reconciler
+
+import (
+	"fmt"
+
+	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
+	"golang.org/x/net/context"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	nseImage       = "nse-vlan"
+	nseEnvItf      = "NSE_VLAN_BASE_IFNAME"
+	nseEnvID       = "NSE_VLAN_ID"
+	nseEnvSerive   = "NSE_SERVICE_NAME"
+	nseEnvPrefixV4 = "NSE_CIDR_PREFIX"
+	nseEnvPrefixV6 = "NSE_IPV6_PREFIX"
+)
+
+type NseDeployment struct {
+	currentStatus *appsv1.Deployment
+	desiredStatus *appsv1.Deployment
+}
+
+func (i *NseDeployment) getEnvVars(dp *appsv1.Deployment, cr *meridiov1alpha1.Trench) []corev1.EnvVar {
+	// if envVars are set in the cr, use the values
+	// else return default envVars
+	allEnv := dp.Spec.Template.Spec.Containers[0].Env
+	env := []corev1.EnvVar{
+		{
+			Name:  nseEnvItf,
+			Value: vlanItf,
+		},
+		{
+			Name:  nseEnvID,
+			Value: vlanID,
+		},
+		{
+			Name:  nseEnvSerive,
+			Value: getVlanNsName(cr),
+		},
+		{
+			Name:  nseEnvPrefixV4,
+			Value: vlanPrefixV4,
+		},
+		{
+			Name:  nseEnvPrefixV6,
+			Value: vlanPrefixV6,
+		},
+	}
+
+	for _, e := range allEnv {
+		// append all hard coded envVars
+		if e.Name == "SPIFFE_ENDPOINT_SOCKET" ||
+			e.Name == "NSE_NAME" ||
+			e.Name == "NSE_CONNECT_TO" ||
+			e.Name == "NSE_POINT2POINT" {
+			env = append(env, e)
+		}
+	}
+	return env
+}
+
+func (i *NseDeployment) insertParamters(dep *appsv1.Deployment, cr *meridiov1alpha1.Trench) *appsv1.Deployment {
+	// if status nse deployment parameters are specified in the cr, use those
+	// else use the default parameters
+	dep.ObjectMeta.Namespace = cr.ObjectMeta.Namespace
+	dep.Spec.Template.Spec.Containers[0].Image = fmt.Sprintf("%s/%s/%s:%s", Registry, OrganizationNsm, nseImage, Tag)
+	dep.Spec.Template.Spec.Containers[0].ImagePullPolicy = PullPolicy
+	dep.Spec.Template.Spec.Containers[0].Env = i.getEnvVars(dep, cr)
+	return dep
+}
+
+func (i *NseDeployment) getModel() (*appsv1.Deployment, error) {
+	return getDeploymentModel("deployment/nse-vlan.yaml")
+}
+
+func (i *NseDeployment) getSelector(cr *meridiov1alpha1.Trench) client.ObjectKey {
+	return client.ObjectKey{
+		Namespace: cr.ObjectMeta.Namespace,
+		Name:      "nse-vlan",
+	}
+}
+
+func (i *NseDeployment) getDesiredStatus(cr *meridiov1alpha1.Trench) error {
+	NseDeployment, err := i.getModel()
+	if err != nil {
+		return err
+	}
+	i.desiredStatus = i.insertParamters(NseDeployment, cr)
+	return nil
+}
+
+// getReconciledDesiredStatus gets the desired status of nse deployment after it's created
+// more paramters than what are defined in the model could be added by K8S
+func (i *NseDeployment) getReconciledDesiredStatus(cd *appsv1.Deployment, cr *meridiov1alpha1.Trench) {
+	i.desiredStatus = i.insertParamters(cd, cr)
+}
+
+func (i *NseDeployment) getCurrentStatus(ctx context.Context, cr *meridiov1alpha1.Trench, client client.Client) error {
+	currentStatus := &appsv1.Deployment{}
+	selector := i.getSelector(cr)
+	err := client.Get(ctx, selector, currentStatus)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	i.currentStatus = currentStatus.DeepCopy()
+	return nil
+}
+
+func (i *NseDeployment) getAction(e *Executor, cr *meridiov1alpha1.Trench) (Action, error) {
+	var action Action
+	err := i.getCurrentStatus(e.ctx, cr, e.client)
+	if err != nil {
+		return action, err
+	}
+	if i.currentStatus == nil {
+		err := i.getDesiredStatus(cr)
+		if err != nil {
+			return action, err
+		}
+		e.log.Info("nse deployment", "add action", "create")
+		action = newCreateAction(i.desiredStatus, "create nse deployment")
+	} else {
+		i.getReconciledDesiredStatus(i.currentStatus, cr)
+		if !equality.Semantic.DeepEqual(i.desiredStatus, i.currentStatus) {
+			e.log.Info("nse deployment", "add action", "update")
+			action = newUpdateAction(i.desiredStatus, "update nse deployment")
+		}
+	}
+	return action, nil
+}

--- a/controllers/reconciler/nsp-service.go
+++ b/controllers/reconciler/nsp-service.go
@@ -1,0 +1,105 @@
+package reconciler
+
+import (
+	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
+	"golang.org/x/net/context"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	nspPort       = 7778
+	nspTargetPort = 7778
+	nspSvcName    = "nsp-service"
+)
+
+type NspService struct {
+	currentStatus *corev1.Service
+	desiredStatus *corev1.Service
+}
+
+func (i *NspService) getPorts(cr *meridiov1alpha1.Trench) []corev1.ServicePort {
+	// if nsp service ports are set in the cr, use the values
+	// else return default service ports
+	return []corev1.ServicePort{
+		{
+			Protocol:   corev1.ProtocolTCP,
+			TargetPort: intstr.FromInt(nspTargetPort),
+			Port:       nspPort,
+		},
+	}
+}
+func (i *NspService) getSelector(cr *meridiov1alpha1.Trench) client.ObjectKey {
+	return client.ObjectKey{
+		Namespace: cr.ObjectMeta.Namespace,
+		Name:      nspSvcName,
+	}
+}
+
+func (i *NspService) insertParamters(svc *corev1.Service, cr *meridiov1alpha1.Trench) *corev1.Service {
+	// if status nsp service parameters are specified in the cr, use those
+	// else use the default parameters
+	svc.ObjectMeta.Namespace = cr.ObjectMeta.Namespace
+	svc.Spec.Ports = i.getPorts(cr)
+	return svc
+}
+
+func (i *NspService) getCurrentStatus(ctx context.Context, cr *meridiov1alpha1.Trench, client client.Client) error {
+	currentStatus := &corev1.Service{}
+	selector := i.getSelector(cr)
+	err := client.Get(ctx, selector, currentStatus)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	i.currentStatus = currentStatus.DeepCopy()
+	return nil
+}
+
+func (i *NspService) getDesiredStatus(cr *meridiov1alpha1.Trench) error {
+	svc, err := i.getModel()
+	if err != nil {
+		return err
+	}
+	i.desiredStatus = i.insertParamters(svc, cr)
+	return nil
+}
+
+// getReconciledDesiredStatus gets the desired status of nsp service after it's created
+// more paramters than what are defined in the model could be added by K8S
+func (i *NspService) getReconciledDesiredStatus(svc *corev1.Service, cr *meridiov1alpha1.Trench) {
+	svc = i.insertParamters(svc, cr)
+	i.desiredStatus = svc
+}
+
+func (i *NspService) getModel() (*corev1.Service, error) {
+	return getServiceModel("deployment/nsp-service.yaml")
+}
+
+func (i *NspService) getAction(e *Executor, cr *meridiov1alpha1.Trench) (Action, error) {
+	var action Action
+	err := i.getCurrentStatus(e.ctx, cr, e.client)
+	if err != nil {
+		return action, err
+	}
+	if i.currentStatus == nil {
+		err := i.getDesiredStatus(cr)
+		if err != nil {
+			return action, err
+		}
+		e.log.Info("nsp service", "add action", "create")
+		action = newCreateAction(i.desiredStatus, "create nsp service")
+	} else {
+		i.getReconciledDesiredStatus(i.currentStatus, cr)
+		if !equality.Semantic.DeepEqual(i.desiredStatus, i.currentStatus) {
+			e.log.Info("nsp service", "add action", "update")
+			action = newUpdateAction(i.desiredStatus, "update nsp service")
+		}
+	}
+	return action, nil
+}

--- a/controllers/reconciler/nsp.go
+++ b/controllers/reconciler/nsp.go
@@ -1,0 +1,110 @@
+package reconciler
+
+import (
+	"fmt"
+
+	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
+	"golang.org/x/net/context"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	nspName    = "nsp"
+	nspEnvName = "NSP_PORT"
+	imageNsp   = "nsp"
+)
+
+type NspDeployment struct {
+	currentStatus *appsv1.Deployment
+	desiredStatus *appsv1.Deployment
+}
+
+func (i *NspDeployment) getEnvVars(cr *meridiov1alpha1.Trench) []corev1.EnvVar {
+	// if envVars are set in the cr, use the values
+	// else return default envVars
+	return []corev1.EnvVar{
+		{
+			Name:  nspEnvName,
+			Value: fmt.Sprint(nspTargetPort),
+		},
+	}
+}
+
+func (i *NspDeployment) insertParamters(dep *appsv1.Deployment, cr *meridiov1alpha1.Trench) *appsv1.Deployment {
+	// if status nsp deployment parameters are specified in the cr, use those
+	// else use the default parameters
+	dep.ObjectMeta.Namespace = cr.ObjectMeta.Namespace
+	dep.Spec.Template.Spec.Containers[0].Image = fmt.Sprintf("%s/%s/%s:%s", Registry, Organization, imageNsp, Tag)
+	dep.Spec.Template.Spec.Containers[0].ImagePullPolicy = PullPolicy
+	dep.Spec.Template.Spec.Containers[0].LivenessProbe = GetLivenessProbe(cr)
+	dep.Spec.Template.Spec.Containers[0].ReadinessProbe = GetReadinessProbe(cr)
+	dep.Spec.Template.Spec.Containers[0].Env = i.getEnvVars(cr)
+	return dep
+}
+
+func (i *NspDeployment) getModel() (*appsv1.Deployment, error) {
+	return getDeploymentModel("deployment/nsp.yaml")
+}
+
+func (i *NspDeployment) getSelector(cr *meridiov1alpha1.Trench) client.ObjectKey {
+	return client.ObjectKey{
+		Namespace: cr.ObjectMeta.Namespace,
+		Name:      nspName,
+	}
+}
+
+func (i *NspDeployment) getDesiredStatus(cr *meridiov1alpha1.Trench) error {
+	NspDeployment, err := i.getModel()
+	if err != nil {
+		return err
+	}
+	i.desiredStatus = i.insertParamters(NspDeployment, cr)
+	return nil
+}
+
+// getNspDeploymentReconciledDesiredStatus gets the desired status of nsp deployment after it's created
+// more paramters than what are defined in the model could be added by K8S
+func (i *NspDeployment) getReconciledDesiredStatus(cd *appsv1.Deployment, cr *meridiov1alpha1.Trench) {
+	i.desiredStatus = i.insertParamters(cd, cr)
+}
+
+func (i *NspDeployment) getCurrentStatus(ctx context.Context, cr *meridiov1alpha1.Trench, client client.Client) error {
+	currentStatus := &appsv1.Deployment{}
+	selector := i.getSelector(cr)
+	err := client.Get(ctx, selector, currentStatus)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	i.currentStatus = currentStatus.DeepCopy()
+	return nil
+}
+
+func (i *NspDeployment) getAction(e *Executor, cr *meridiov1alpha1.Trench) (Action, error) {
+	var action Action
+	err := i.getCurrentStatus(e.ctx, cr, e.client)
+	if err != nil {
+		return action, err
+	}
+	if i.currentStatus == nil {
+		err := i.getDesiredStatus(cr)
+		if err != nil {
+			return action, err
+		}
+		e.log.Info("nsp deployment", "add action", "create")
+		action = newCreateAction(i.desiredStatus, "create nsp deployment")
+	} else {
+		i.getReconciledDesiredStatus(i.currentStatus, cr)
+		if !equality.Semantic.DeepEqual(i.desiredStatus, i.currentStatus) {
+			e.log.Info("nsp deployment", "add action", "update")
+			action = newUpdateAction(i.desiredStatus, "update nsp deployment")
+		}
+	}
+	return action, nil
+}

--- a/controllers/reconciler/proxy.go
+++ b/controllers/reconciler/proxy.go
@@ -1,0 +1,161 @@
+package reconciler
+
+import (
+	"fmt"
+
+	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
+	"golang.org/x/net/context"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	imageProxy            = "proxy"
+	proxyEnvConfig        = "NSM_CONFIG_MAP_NAME"
+	proxyEnvService       = "NSM_SERVICE_NAME"
+	proxyEnvVip           = "NSM_VIPS"
+	proxyEnvSubnetPools   = "NSM_SUBNET_POOLS"
+	proxyEnvSubnetLengths = "NSM_SUBNET_PREFIX_LENGTHS"
+	proxyEnvIpam          = "NSM_IPAM_SERVICE"
+	proxyEnvLb            = "NSM_NETWORK_SERVICE_NAME"
+	proxyEnvNsp           = "NSM_NSP_SERVICE"
+)
+
+type Proxy struct {
+	currentStatus *appsv1.DaemonSet
+	desiredStatus *appsv1.DaemonSet
+}
+
+func (i *Proxy) getEnvVars(ds *appsv1.DaemonSet, cr *meridiov1alpha1.Trench) []corev1.EnvVar {
+	// if envVars are set in the cr, use the values
+	// else return default envVars
+	allEnv := ds.Spec.Template.Spec.Containers[0].Env
+	env := []corev1.EnvVar{
+		{
+			Name:  proxyEnvConfig,
+			Value: cr.Spec.ConfigMapName,
+		},
+		{
+			Name:  proxyEnvVip,
+			Value: getVips(cr),
+		},
+		{
+			Name:  proxyEnvSubnetPools,
+			Value: getSubnetPool(cr),
+		},
+		{
+			Name:  proxyEnvSubnetLengths,
+			Value: getPrefixLength(cr),
+		},
+		{
+			Name:  proxyEnvService,
+			Value: fmt.Sprintf("%s.%s", proxyNetworkService, cr.ObjectMeta.Namespace),
+		},
+		{
+			Name:  proxyEnvIpam,
+			Value: fmt.Sprintf("ipam-service:%d", ipamTargetPort),
+		},
+		{
+			Name:  proxyEnvNsp,
+			Value: fmt.Sprintf("nsp-service:%d", nspTargetPort),
+		},
+		{
+			Name:  proxyEnvLb,
+			Value: fmt.Sprintf("%s.%s", lbNetworkService, cr.ObjectMeta.Namespace),
+		},
+	}
+
+	for _, e := range allEnv {
+		// append all hard coded envVars
+		if e.Name == "SPIFFE_ENDPOINT_SOCKET" ||
+			e.Name == "NSM_NAME" ||
+			e.Name == "NSM_HOST" ||
+			e.Name == "NSM_NAMESPACE" ||
+			e.Name == "NSM_CONNECT_TO" {
+			env = append(env, e)
+		}
+	}
+
+	return env
+}
+
+func (i *Proxy) insertParamters(ds *appsv1.DaemonSet, cr *meridiov1alpha1.Trench) *appsv1.DaemonSet {
+	// if status proxy daemonset parameters are specified in the cr, use those
+	// else use the default parameters
+	ds.ObjectMeta.Namespace = cr.ObjectMeta.Namespace
+	// init container
+	ds.Spec.Template.Spec.InitContainers[0].Image = fmt.Sprintf("%s/%s/%s:%s", Registry, Organization, busyboxImage, busyboxTag)
+	// proxy container
+	ds.Spec.Template.Spec.Containers[0].Image = fmt.Sprintf("%s/%s/%s:%s", Registry, Organization, imageProxy, Tag)
+	ds.Spec.Template.Spec.Containers[0].ImagePullPolicy = PullPolicy
+	ds.Spec.Template.Spec.Containers[0].LivenessProbe = GetLivenessProbe(cr)
+	ds.Spec.Template.Spec.Containers[0].ReadinessProbe = GetReadinessProbe(cr)
+	ds.Spec.Template.Spec.Containers[0].Env = i.getEnvVars(ds, cr)
+	return ds
+}
+
+func (i *Proxy) getModel() (*appsv1.DaemonSet, error) {
+	return getDaemonsetModel("deployment/proxy.yaml")
+}
+
+func (i *Proxy) getSelector(cr *meridiov1alpha1.Trench) client.ObjectKey {
+	return client.ObjectKey{
+		Namespace: cr.ObjectMeta.Namespace,
+		Name:      "proxy",
+	}
+}
+
+func (i *Proxy) getDesiredStatus(cr *meridiov1alpha1.Trench) error {
+	proxy, err := i.getModel()
+	if err != nil {
+		return err
+	}
+	i.desiredStatus = i.insertParamters(proxy, cr)
+	return nil
+}
+
+// getReconciledDesiredStatus gets the desired status of proxy daemonset after it's created
+// more paramters than what are defined in the model could be added by K8S
+func (i *Proxy) getReconciledDesiredStatus(cd *appsv1.DaemonSet, cr *meridiov1alpha1.Trench) {
+	i.desiredStatus = i.insertParamters(cd, cr)
+}
+
+func (i *Proxy) getCurrentStatus(ctx context.Context, cr *meridiov1alpha1.Trench, client client.Client) error {
+	currentStatus := &appsv1.DaemonSet{}
+	selector := i.getSelector(cr)
+	err := client.Get(ctx, selector, currentStatus)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	i.currentStatus = currentStatus.DeepCopy()
+	return nil
+}
+
+func (i *Proxy) getAction(e *Executor, cr *meridiov1alpha1.Trench) (Action, error) {
+	var action Action
+	err := i.getCurrentStatus(e.ctx, cr, e.client)
+	if err != nil {
+		return action, err
+	}
+	if i.currentStatus == nil {
+		err := i.getDesiredStatus(cr)
+		if err != nil {
+			return action, err
+		}
+		e.log.Info("proxy daemonset", "add action", "create")
+		action = newCreateAction(i.desiredStatus, "create proxy daemonset")
+	} else {
+		i.getReconciledDesiredStatus(i.currentStatus, cr)
+		if !equality.Semantic.DeepEqual(i.desiredStatus, i.currentStatus) {
+			e.log.Info("proxy daemonset", "add action", "update")
+			action = newUpdateAction(i.desiredStatus, "update proxy daemonset")
+		}
+	}
+	return action, nil
+}

--- a/controllers/reconciler/resources.go
+++ b/controllers/reconciler/resources.go
@@ -22,6 +22,8 @@ type Meridio struct {
 	serviceAccount *ServiceAccount
 	role           *Role
 	roleBinding    *RoleBinding
+	nspDeployment  *NspDeployment
+	nspService     *NspService
 }
 
 func NewMeridio() *Meridio {
@@ -33,6 +35,8 @@ func NewMeridio() *Meridio {
 		serviceAccount: &ServiceAccount{},
 		role:           &Role{},
 		roleBinding:    &RoleBinding{},
+		nspDeployment:  &NspDeployment{},
+		nspService:     &NspService{},
 	}
 }
 
@@ -46,6 +50,8 @@ func (m Meridio) ReconcileAll(e *Executor, cr *meridiov1alpha1.Trench) error {
 		m.role,
 		m.roleBinding,
 		m.loadBalancer,
+		m.nspDeployment,
+		m.nspService,
 	}
 
 	for _, r := range resources {

--- a/controllers/reconciler/resources.go
+++ b/controllers/reconciler/resources.go
@@ -25,6 +25,7 @@ type Meridio struct {
 	nspDeployment  *NspDeployment
 	nspService     *NspService
 	proxy          *Proxy
+	nseDeployment  *NseDeployment
 }
 
 func NewMeridio() *Meridio {
@@ -39,6 +40,7 @@ func NewMeridio() *Meridio {
 		nspDeployment:  &NspDeployment{},
 		nspService:     &NspService{},
 		proxy:          &Proxy{},
+		nseDeployment:  &NseDeployment{},
 	}
 }
 
@@ -55,6 +57,7 @@ func (m Meridio) ReconcileAll(e *Executor, cr *meridiov1alpha1.Trench) error {
 		m.nspDeployment,
 		m.nspService,
 		m.proxy,
+		m.nseDeployment,
 	}
 
 	for _, r := range resources {

--- a/controllers/reconciler/resources.go
+++ b/controllers/reconciler/resources.go
@@ -18,6 +18,10 @@ type Meridio struct {
 	ipamDeployment *IpamDeployment
 	ipamService    *IpamService
 	configmap      *ConfigMap
+	loadBalancer   *LoadBalancer
+	serviceAccount *ServiceAccount
+	role           *Role
+	roleBinding    *RoleBinding
 }
 
 func NewMeridio() *Meridio {
@@ -25,6 +29,10 @@ func NewMeridio() *Meridio {
 		ipamDeployment: &IpamDeployment{},
 		ipamService:    &IpamService{},
 		configmap:      &ConfigMap{},
+		loadBalancer:   &LoadBalancer{},
+		serviceAccount: &ServiceAccount{},
+		role:           &Role{},
+		roleBinding:    &RoleBinding{},
 	}
 }
 
@@ -34,6 +42,10 @@ func (m Meridio) ReconcileAll(e *Executor, cr *meridiov1alpha1.Trench) error {
 		m.ipamDeployment,
 		m.ipamService,
 		m.configmap,
+		m.serviceAccount,
+		m.role,
+		m.roleBinding,
+		m.loadBalancer,
 	}
 
 	for _, r := range resources {

--- a/controllers/reconciler/resources.go
+++ b/controllers/reconciler/resources.go
@@ -1,0 +1,54 @@
+package reconciler
+
+import (
+	"fmt"
+
+	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
+	"golang.org/x/net/context"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Resources interface {
+	getCurrentStatus(ctx context.Context, cr *meridiov1alpha1.Trench, client client.Client) error
+	getDesiredStatus(cr *meridiov1alpha1.Trench) error
+	getAction(e *Executor, cr *meridiov1alpha1.Trench) (Action, error)
+}
+
+type Meridio struct {
+	ipamDeployment *IpamDeployment
+	ipamService    *IpamService
+	configmap      *ConfigMap
+}
+
+func NewMeridio() *Meridio {
+	return &Meridio{
+		ipamDeployment: &IpamDeployment{},
+		ipamService:    &IpamService{},
+		configmap:      &ConfigMap{},
+	}
+}
+
+func (m Meridio) ReconcileAll(e *Executor, cr *meridiov1alpha1.Trench) error {
+	var actions []Action
+	resources := []Resources{
+		m.ipamDeployment,
+		m.ipamService,
+		m.configmap,
+	}
+
+	for _, r := range resources {
+		action, err := r.getAction(e, cr)
+		if err != nil {
+			return fmt.Errorf("get %t action error: %s", r, err)
+		}
+		if action != nil {
+			actions = append(actions, action)
+		}
+	}
+
+	err := e.runAll(actions)
+	if err != nil {
+		return fmt.Errorf("running actions error: %s", err)
+	}
+	return nil
+}

--- a/controllers/reconciler/resources.go
+++ b/controllers/reconciler/resources.go
@@ -24,6 +24,7 @@ type Meridio struct {
 	roleBinding    *RoleBinding
 	nspDeployment  *NspDeployment
 	nspService     *NspService
+	proxy          *Proxy
 }
 
 func NewMeridio() *Meridio {
@@ -37,6 +38,7 @@ func NewMeridio() *Meridio {
 		roleBinding:    &RoleBinding{},
 		nspDeployment:  &NspDeployment{},
 		nspService:     &NspService{},
+		proxy:          &Proxy{},
 	}
 }
 
@@ -52,6 +54,7 @@ func (m Meridio) ReconcileAll(e *Executor, cr *meridiov1alpha1.Trench) error {
 		m.loadBalancer,
 		m.nspDeployment,
 		m.nspService,
+		m.proxy,
 	}
 
 	for _, r := range resources {

--- a/controllers/reconciler/role-binding.go
+++ b/controllers/reconciler/role-binding.go
@@ -1,0 +1,84 @@
+package reconciler
+
+import (
+	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
+	"golang.org/x/net/context"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	roleBindingName = "meridio-configuration-role-binding"
+)
+
+type RoleBinding struct {
+	currentStatus *rbacv1.RoleBinding
+	desiredStatus *rbacv1.RoleBinding
+}
+
+func (r *RoleBinding) getModel() (*rbacv1.RoleBinding, error) {
+	return getRoleBindingModel("deployment/role-binding.yaml")
+}
+
+func (r *RoleBinding) insertParamters(role *rbacv1.RoleBinding, cr *meridiov1alpha1.Trench) *rbacv1.RoleBinding {
+	role.ObjectMeta.Namespace = cr.ObjectMeta.Namespace
+	return role
+}
+
+func (r *RoleBinding) getSelector(cr *meridiov1alpha1.Trench) client.ObjectKey {
+	return client.ObjectKey{
+		Namespace: cr.ObjectMeta.Namespace,
+		Name:      roleBindingName,
+	}
+}
+
+func (r *RoleBinding) getCurrentStatus(ctx context.Context, cr *meridiov1alpha1.Trench, client client.Client) error {
+	currentState := &rbacv1.RoleBinding{}
+	err := client.Get(ctx, r.getSelector(cr), currentState)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	r.currentStatus = currentState.DeepCopy()
+	return nil
+}
+
+func (r *RoleBinding) getDesiredStatus(cr *meridiov1alpha1.Trench) error {
+	model, err := r.getModel()
+	if err != nil {
+		return err
+	}
+	r.desiredStatus = r.insertParamters(model, cr)
+	return nil
+}
+
+func (r *RoleBinding) getReconciledDesiredStatus(current *rbacv1.RoleBinding, cr *meridiov1alpha1.Trench) {
+	r.desiredStatus = r.insertParamters(current, cr).DeepCopy()
+}
+
+func (r *RoleBinding) getAction(e *Executor, cr *meridiov1alpha1.Trench) (Action, error) {
+	var action Action
+	err := r.getCurrentStatus(e.ctx, cr, e.client)
+	if err != nil {
+		return action, err
+	}
+	if r.currentStatus == nil {
+		err = r.getDesiredStatus(cr)
+		if err != nil {
+			return action, err
+		}
+		e.log.Info("role binding", "add action", "create")
+		action = newCreateAction(r.desiredStatus, "create role binding")
+	} else {
+		r.getReconciledDesiredStatus(r.currentStatus, cr)
+		if !equality.Semantic.DeepEqual(r.desiredStatus, r.currentStatus) {
+			e.log.Info("role binding", "add action", "update")
+			action = newUpdateAction(r.desiredStatus, "update role binding")
+		}
+	}
+	return action, nil
+}

--- a/controllers/reconciler/role.go
+++ b/controllers/reconciler/role.go
@@ -1,0 +1,84 @@
+package reconciler
+
+import (
+	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
+	"golang.org/x/net/context"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	roleName = "meridio-configuration-role"
+)
+
+type Role struct {
+	currentStatus *rbacv1.Role
+	desiredStatus *rbacv1.Role
+}
+
+func (r *Role) getSelector(cr *meridiov1alpha1.Trench) client.ObjectKey {
+	return client.ObjectKey{
+		Namespace: cr.ObjectMeta.Namespace,
+		Name:      roleName,
+	}
+}
+
+func (r *Role) getModel() (*rbacv1.Role, error) {
+	return getRoleModel("deployment/role.yaml")
+}
+
+func (r *Role) insertParamters(role *rbacv1.Role, cr *meridiov1alpha1.Trench) *rbacv1.Role {
+	role.ObjectMeta.Namespace = cr.ObjectMeta.Namespace
+	return role
+}
+
+func (r *Role) getCurrentStatus(ctx context.Context, cr *meridiov1alpha1.Trench, client client.Client) error {
+	currentState := &rbacv1.Role{}
+	err := client.Get(ctx, r.getSelector(cr), currentState)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	r.currentStatus = currentState.DeepCopy()
+	return nil
+}
+
+func (r *Role) getDesiredStatus(cr *meridiov1alpha1.Trench) error {
+	model, err := r.getModel()
+	if err != nil {
+		return err
+	}
+	r.desiredStatus = r.insertParamters(model, cr)
+	return nil
+}
+
+func (r *Role) getReconciledDesiredStatus(current *rbacv1.Role, cr *meridiov1alpha1.Trench) {
+	r.desiredStatus = r.insertParamters(current, cr).DeepCopy()
+}
+
+func (r *Role) getAction(e *Executor, cr *meridiov1alpha1.Trench) (Action, error) {
+	var action Action
+	err := r.getCurrentStatus(e.ctx, cr, e.client)
+	if err != nil {
+		return action, err
+	}
+	if r.currentStatus == nil {
+		err = r.getDesiredStatus(cr)
+		if err != nil {
+			return action, err
+		}
+		e.log.Info("role", "add action", "create")
+		action = newCreateAction(r.desiredStatus, "create role")
+	} else {
+		r.getReconciledDesiredStatus(r.currentStatus, cr)
+		if !equality.Semantic.DeepEqual(r.desiredStatus, r.currentStatus) {
+			e.log.Info("role", "add action", "update")
+			action = newUpdateAction(r.desiredStatus, "update role")
+		}
+	}
+	return action, nil
+}

--- a/controllers/reconciler/service-account.go
+++ b/controllers/reconciler/service-account.go
@@ -1,0 +1,80 @@
+package reconciler
+
+import (
+	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
+	"golang.org/x/net/context"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const serviceAccountName = "meridio"
+
+type ServiceAccount struct {
+	currentStatus *corev1.ServiceAccount
+	desiredStatus *corev1.ServiceAccount
+}
+
+func (sa *ServiceAccount) getSelector(cr *meridiov1alpha1.Trench) client.ObjectKey {
+	return client.ObjectKey{
+		Namespace: cr.ObjectMeta.Namespace,
+		Name:      serviceAccountName,
+	}
+}
+
+func (sa *ServiceAccount) insertParamters(role *corev1.ServiceAccount, cr *meridiov1alpha1.Trench) *corev1.ServiceAccount {
+	role.ObjectMeta.Namespace = cr.ObjectMeta.Namespace
+	return role
+}
+
+func (sa *ServiceAccount) getCurrentStatus(ctx context.Context, cr *meridiov1alpha1.Trench, client client.Client) error {
+	currentState := &corev1.ServiceAccount{}
+	err := client.Get(ctx, sa.getSelector(cr), currentState)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	sa.currentStatus = sa.insertParamters(currentState, cr)
+	return nil
+}
+
+func (sa *ServiceAccount) getDesiredStatus(cr *meridiov1alpha1.Trench) error {
+	sa.desiredStatus = &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceAccountName,
+			Namespace: cr.ObjectMeta.Namespace,
+		},
+	}
+	return nil
+}
+
+func (sa *ServiceAccount) getReconciledDesiredStatus(current *corev1.ServiceAccount, cr *meridiov1alpha1.Trench) {
+	sa.desiredStatus = sa.insertParamters(current, cr).DeepCopy()
+}
+
+func (sa *ServiceAccount) getAction(e *Executor, cr *meridiov1alpha1.Trench) (Action, error) {
+	var action Action
+	err := sa.getCurrentStatus(e.ctx, cr, e.client)
+	if err != nil {
+		return action, err
+	}
+	if sa.currentStatus == nil {
+		err = sa.getDesiredStatus(cr)
+		if err != nil {
+			return action, err
+		}
+		e.log.Info("service account", "add action", "create")
+		action = newCreateAction(sa.desiredStatus, "create service account")
+	} else {
+		sa.getReconciledDesiredStatus(sa.currentStatus, cr)
+		if !equality.Semantic.DeepEqual(sa.desiredStatus, sa.currentStatus) {
+			e.log.Info("service account", "add action", "update")
+			action = newUpdateAction(sa.desiredStatus, "update service account")
+		}
+	}
+	return action, nil
+}

--- a/controllers/trench_controller.go
+++ b/controllers/trench_controller.go
@@ -23,6 +23,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -46,6 +47,9 @@ type TrenchReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -85,5 +89,8 @@ func (r *TrenchReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Service{}).
 		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.ServiceAccount{}).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
 		Complete(r)
 }

--- a/controllers/trench_controller.go
+++ b/controllers/trench_controller.go
@@ -46,6 +46,7 @@ type TrenchReconciler struct {
 //+kubebuilder:rbac:groups=meridio.nordix.org,resources=trenches/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
@@ -92,5 +93,6 @@ func (r *TrenchReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&rbacv1.Role{}).
 		Owns(&rbacv1.RoleBinding{}).
+		Owns(&appsv1.DaemonSet{}).
 		Complete(r)
 }

--- a/controllers/trench_controller.go
+++ b/controllers/trench_controller.go
@@ -18,21 +18,19 @@ package controllers
 
 import (
 	"context"
-	"log"
 
 	"github.com/go-logr/logr"
-	"gopkg.in/yaml.v2"
+
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
+	"github.com/nordix/meridio-operator/controllers/reconciler"
 )
 
 // TrenchReconciler reconciles a Trench object
@@ -42,16 +40,12 @@ type TrenchReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-const MeridioConfigKey = "meridio.conf"
-
-type Config struct {
-	VIPs []string `yaml:"vips"`
-}
-
 //+kubebuilder:rbac:groups=meridio.nordix.org,resources=trenches,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=meridio.nordix.org,resources=trenches/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=meridio.nordix.org,resources=trenches/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -68,103 +62,20 @@ func (r *TrenchReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	trench := &meridiov1alpha1.Trench{}
 	err := r.Get(ctx, req.NamespacedName, trench)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 		return ctrl.Result{}, err
 	}
 
-	// Check if the configmap already exists, if not create a new one
-	configMap := &corev1.ConfigMap{}
-	err = r.Client.Get(ctx, client.ObjectKey{Namespace: trench.Name, Name: trench.Spec.ConfigMapName}, configMap)
-	if apierrors.IsNotFound(err) {
-		configMap = r.buildConfigMap(trench)
-		err := r.Client.Create(ctx, configMap)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{}, nil
-	}
+	executor := reconciler.NewExecutor(r.Scheme, r.Client, ctx, trench)
+	meridio := reconciler.NewMeridio()
+	err = meridio.ReconcileAll(executor, trench)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	// Ensure the configmap contains the same data as the spec
-	if !configMapValid(trench, configMap) {
-		r.setConfigMapData(trench, configMap)
-		err = r.Update(ctx, configMap)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{}, nil
-	}
-
 	return ctrl.Result{}, nil
-}
-
-func (r *TrenchReconciler) setConfigMapData(trench *meridiov1alpha1.Trench, configMap *corev1.ConfigMap) {
-	config := &Config{
-		VIPs: trench.Spec.VIPs,
-	}
-	configYAML, err := yaml.Marshal(&config)
-	if err != nil {
-		log.Fatalf("error yaml.Marshal: %v", err)
-	}
-	configMap.Data = map[string]string{
-		MeridioConfigKey: string(configYAML),
-	}
-	configMap.Data[MeridioConfigKey] = string(configYAML)
-}
-
-func (r *TrenchReconciler) buildConfigMap(trench *meridiov1alpha1.Trench) *corev1.ConfigMap {
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      trench.Spec.ConfigMapName,
-			Namespace: trench.Name,
-		},
-	}
-	r.setConfigMapData(trench, configMap)
-
-	controllerutil.SetControllerReference(trench, configMap, r.Scheme)
-	return configMap
-}
-
-func configMapValid(trench *meridiov1alpha1.Trench, configMap *corev1.ConfigMap) bool {
-	configuration, ok := configMap.Data[MeridioConfigKey]
-	if !ok {
-		return false
-	}
-	config := &Config{}
-	err := yaml.Unmarshal([]byte(configuration), &config)
-	if err != nil {
-		return false
-	}
-	if !vipListsEqual(config.VIPs, trench.Spec.VIPs) {
-		return false
-	}
-	return true
-}
-
-func vipListsEqual(vipListA []string, vipListB []string) bool {
-	vipsA := make(map[string]struct{})
-	vipsB := make(map[string]struct{})
-	for _, vip := range vipListA {
-		vipsA[vip] = struct{}{}
-	}
-	for _, vip := range vipListB {
-		vipsB[vip] = struct{}{}
-	}
-	for _, vip := range vipListA {
-		if _, ok := vipsB[vip]; !ok {
-			return false
-		}
-	}
-	for _, vip := range vipListB {
-		if _, ok := vipsA[vip]; !ok {
-			return false
-		}
-	}
-	return true
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -172,5 +83,7 @@ func (r *TrenchReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&meridiov1alpha1.Trench{}).
 		Owns(&corev1.ConfigMap{}).
+		Owns(&corev1.Service{}).
+		Owns(&appsv1.Deployment{}).
 		Complete(r)
 }

--- a/deployment/ipam-service.yaml
+++ b/deployment/ipam-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ipam-service
+spec:
+  selector:
+    app: ipam
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 7777
+      targetPort: 7777

--- a/deployment/ipam.yaml
+++ b/deployment/ipam.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ipam
+  labels:
+    app: ipam
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ipam
+  template:
+    metadata:
+      labels:
+        app: ipam
+    spec:
+      containers:
+        - name: ipam
+          image: registry.nordix.org/cloud-native/meridio/ipam:latest
+          imagePullPolicy: IfNotPresent
+          readinessProbe:
+            exec:
+              command: ["/bin/grpc_health_probe", "-addr=:8000", "-connect-timeout=100ms", "-rpc-timeout=150ms"]
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 5
+          livenessProbe:
+              exec:
+                command: ["/bin/grpc_health_probe", "-addr=:8000", "-connect-timeout=100ms", "-rpc-timeout=150ms"]
+              initialDelaySeconds: 0
+              periodSeconds: 10
+              timeoutSeconds: 3
+              failureThreshold: 5
+          env:
+            - name: IPAM_PORT
+              value: "7777"

--- a/deployment/load-balancer.yaml
+++ b/deployment/load-balancer.yaml
@@ -1,0 +1,137 @@
+# Source: meridio/templates/load-balancer.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: load-balancer
+  labels:
+    app: load-balancer
+spec:
+  selector:
+    matchLabels:
+      app: load-balancer
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: load-balancer
+    spec:
+      serviceAccountName: meridio
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - "load-balancer"
+            topologyKey: kubernetes.io/hostname
+      initContainers:
+        - name: sysctl-init
+          image: registry.nordix.org/cloud-native/meridio/busybox:1.29
+          securityContext:
+            privileged: true
+          command: ["/bin/sh"]
+          args:
+            - -c
+            - sysctl -w net.ipv6.conf.all.forwarding=1 ; sysctl -w net.ipv4.conf.all.forwarding=1 ; sysctl -w net.ipv4.fib_multipath_hash_policy=1 ; sysctl -w net.ipv6.fib_multipath_hash_policy=1
+      containers:
+        - name: load-balancer
+          image: registry.nordix.org/cloud-native/meridio/load-balancer:latest
+          imagePullPolicy: IfNotPresent
+          readinessProbe:
+            exec:
+              command:
+              - /bin/grpc_health_probe
+              - -addr=:8000
+              - -connect-timeout=100ms
+              - -rpc-timeout=150ms
+            failureThreshold: 5
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 3
+          livenessProbe:
+            exec:
+              command:
+              - /bin/grpc_health_probe
+              - -addr=:8000
+              - -connect-timeout=100ms
+              - -rpc-timeout=150ms
+            failureThreshold: 5
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 3
+          env:
+            - name: SPIFFE_ENDPOINT_SOCKET
+              value: unix:///run/spire/sockets/agent.sock
+            - name: NSM_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NSM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NSM_CONFIG_MAP_NAME
+              value: meridio-configuration
+            - name: NSM_CONNECT_TO
+              value: unix:///var/lib/networkservicemesh/nsm.io.sock
+            - name: NSM_SERVICE_NAME
+              value: load-balancer.default
+            - name: NSM_NSP_SERVICE
+              value: nsp-service:7778
+          volumeMounts:
+            - name: spire-agent-socket
+              mountPath: /run/spire/sockets
+              readOnly: true
+            - name: nsm-socket
+              mountPath: /var/lib/networkservicemesh
+              readOnly: false
+          securityContext:
+            privileged: true
+        - name: nsc
+          image: registry.nordix.org/cloud-native/nsm/cmd-nsc:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: SPIFFE_ENDPOINT_SOCKET
+              value: unix:///run/spire/sockets/agent.sock
+            - name: NSM_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NSM_NETWORK_SERVICES
+              value: vlan://external-vlan.default/ext-vlan?forwarder=forwarder-vlan
+            - name: NSM_DIAL_TIMEOUT
+              value: "30s"
+            - name: NSM_REQUEST_TIMEOUT
+              value: "300s"
+          volumeMounts:
+            - name: spire-agent-socket
+              mountPath: /run/spire/sockets
+              readOnly: true
+            - name: nsm-socket
+              mountPath: /var/lib/networkservicemesh
+              readOnly: true
+        - name: fe
+          image: registry.nordix.org/cloud-native/meridio/frontend:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NFE_VIPS
+              value: 20.0.0.1/32
+            - name: NFE_GATEWAYS
+              value: 169.254.100.254/24,fe80::beef/64,169.254.100.253/24,fe80::beee/64
+            - name: NFE_LOG_BIRD
+              value: "true"
+            - name: NFE_ECMP
+              value: "true"
+          securityContext:
+            privileged: true
+      volumes:
+        - name: spire-agent-socket
+          hostPath:
+            path: /run/spire/sockets
+            type: Directory
+        - name: nsm-socket
+          hostPath:
+            path: /var/lib/networkservicemesh
+            type: DirectoryOrCreate

--- a/deployment/nse-vlan.yaml
+++ b/deployment/nse-vlan.yaml
@@ -1,0 +1,57 @@
+# Source: meridio/templates/nse-vlan.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nse-vlan
+  labels:
+    app: nse-vlan
+spec:
+  selector:
+    matchLabels:
+      app: nse-vlan
+  template:
+    metadata:
+      labels:
+        app: nse-vlan
+    spec:
+      containers:
+        - name: nse
+          image: registry.nordix.org/cloud-native/nsm/nse-vlan:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: SPIFFE_ENDPOINT_SOCKET
+              value: unix:///run/spire/sockets/agent.sock
+            - name: NSE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NSE_CONNECT_TO
+              value: unix:///var/lib/networkservicemesh/nsm.io.sock
+            - name: NSE_VLAN_BASE_IFNAME
+              value: eth0
+            - name: NSE_VLAN_ID
+              value: "100"
+            - name: NSE_SERVICE_NAME
+              value: external-vlan.default
+            - name: NSE_CIDR_PREFIX
+              value: "169.254.100.0/24"
+            - name: NSE_IPV6_PREFIX
+              value: "100:100::/64"
+            - name: NSE_POINT2POINT
+              value: "False"
+          volumeMounts:
+            - name: spire-agent-socket
+              mountPath: /run/spire/sockets
+              readOnly: true
+            - name: nsm-socket
+              mountPath: /var/lib/networkservicemesh
+              readOnly: false
+      volumes:
+        - name: spire-agent-socket
+          hostPath:
+            path: /run/spire/sockets
+            type: Directory
+        - name: nsm-socket
+          hostPath:
+            path: /var/lib/networkservicemesh
+            type: DirectoryOrCreate

--- a/deployment/nsp-service.yaml
+++ b/deployment/nsp-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nsp-service
+spec:
+  selector:
+    app: nsp
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 7778
+      targetPort: 7778

--- a/deployment/nsp.yaml
+++ b/deployment/nsp.yaml
@@ -1,0 +1,46 @@
+# Source: meridio/templates/nsp.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nsp
+  labels:
+    app: nsp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nsp
+  template:
+    metadata:
+      labels:
+        app: nsp
+    spec:
+      containers:
+        - name: nsp
+          image: registry.nordix.org/cloud-native/meridio/nsp:latest
+          imagePullPolicy: IfNotPresent
+          readinessProbe:
+            exec:
+              command:
+              - /bin/grpc_health_probe
+              - -addr=:8000
+              - -connect-timeout=100ms
+              - -rpc-timeout=150ms
+            failureThreshold: 5
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 3
+          livenessProbe:
+            exec:
+              command:
+              - /bin/grpc_health_probe
+              - -addr=:8000
+              - -connect-timeout=100ms
+              - -rpc-timeout=150ms
+            failureThreshold: 5
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 3
+          env:
+            - name: NSP_PORT
+              value: "7778"

--- a/deployment/proxy.yaml
+++ b/deployment/proxy.yaml
@@ -1,0 +1,103 @@
+# Source: meridio/templates/proxy.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: proxy
+  labels:
+    app: proxy
+spec:
+  selector:
+    matchLabels:
+      app: proxy
+  template:
+    metadata:
+      labels:
+        app: proxy
+    spec:
+      serviceAccountName: meridio
+      initContainers:
+        - name: sysctl-init
+          image: registry.nordix.org/cloud-native/meridio/busybox:1.29
+          securityContext:
+            privileged: true
+          command: ["/bin/sh"]
+          args:
+            - -c
+            - sysctl -w net.ipv6.conf.all.forwarding=1 ; sysctl -w net.ipv4.conf.all.forwarding=1 ; sysctl -w net.ipv6.conf.all.accept_dad=0 ; sysctl -w net.ipv4.fib_multipath_hash_policy=1 ; sysctl -w net.ipv6.fib_multipath_hash_policy=1
+      containers:
+        - name: proxy
+          image: registry.nordix.org/cloud-native/meridio/proxy:latest
+          imagePullPolicy: IfNotPresent
+          readinessProbe:
+            exec:
+              command:
+              - /bin/grpc_health_probe
+              - -addr=:8000
+              - -connect-timeout=100ms
+              - -rpc-timeout=150ms
+            failureThreshold: 5
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 3
+          livenessProbe:
+            exec:
+              command:
+              - /bin/grpc_health_probe
+              - -addr=:8000
+              - -connect-timeout=100ms
+              - -rpc-timeout=150ms
+            failureThreshold: 5
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 3
+          env:
+            - name: SPIFFE_ENDPOINT_SOCKET
+              value: unix:///run/spire/sockets/agent.sock
+            - name: NSM_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NSM_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: NSM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NSM_CONFIG_MAP_NAME
+              value: meridio-configuration
+            - name: NSM_CONNECT_TO
+              value: unix:///var/lib/networkservicemesh/nsm.io.sock
+            - name: NSM_SERVICE_NAME
+              value: proxy.load-balancer.default
+            - name: NSM_VIPS
+              value: 20.0.0.1/32
+            - name: NSM_SUBNET_POOLS
+              value: 172.16.0.0/16
+            - name: NSM_SUBNET_PREFIX_LENGTHS
+              value: "24"
+            - name: NSM_IPAM_SERVICE
+              value: ipam-service:7777
+            - name: NSM_NETWORK_SERVICE_NAME
+              value: load-balancer.default
+            - name: NSM_NSP_SERVICE
+              value: nsp-service:7778
+          volumeMounts:
+            - name: spire-agent-socket
+              mountPath: /run/spire/sockets
+              readOnly: true
+            - name: nsm-socket
+              mountPath: /var/lib/networkservicemesh
+              readOnly: true
+          securityContext:
+            privileged: true
+      volumes:
+        - name: spire-agent-socket
+          hostPath:
+            path: /run/spire/sockets
+            type: Directory
+        - name: nsm-socket
+          hostPath:
+            path: /var/lib/networkservicemesh
+            type: DirectoryOrCreate

--- a/deployment/role-binding.yaml
+++ b/deployment/role-binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: meridio-configuration-role-binding
+subjects:
+- kind: ServiceAccount
+  name: meridio
+roleRef:
+  kind: Role
+  name: meridio-configuration-role
+  apiGroup: rbac.authorization.k8s.io

--- a/deployment/role.yaml
+++ b/deployment/role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: meridio-configuration-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - watch

--- a/deployment/service-account.yaml
+++ b/deployment/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: meridio

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
 	github.com/vishvananda/netlink v1.1.0
+	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.19.2
 	k8s.io/apimachinery v0.19.2


### PR DESCRIPTION
Meridio should be initialized by applying a custom resource
All relevant resources should be created and updated by the custom resource.

- [x] a framework for all resources
- [x] ipam deployment and service
- [x] configmap
- [x] load-balancer deployment
- [x] nse-vlan
- [x] nsp-service and deployment
- [x] proxy