### PR TITLE
Trench name support (resource names and env variables)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -48,6 +48,9 @@ spec:
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager
+        env:
+          - name: RESOURCE_NAME_PREFIX
+            value: ""
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:

--- a/controllers/reconciler/configmap.go
+++ b/controllers/reconciler/configmap.go
@@ -17,7 +17,7 @@ const (
 )
 
 func getConfigMapName(cr *meridiov1alpha1.Trench) string {
-	return fmt.Sprintf("%s-%s", cr.Spec.ConfigMapName, cr.ObjectMeta.Name)
+	return getFullName(cr, cr.Spec.ConfigMapName)
 }
 
 type Config struct {

--- a/controllers/reconciler/configmap.go
+++ b/controllers/reconciler/configmap.go
@@ -16,6 +16,10 @@ const (
 	MeridioConfigKey = "meridio.conf"
 )
 
+func getConfigMapName(cr *meridiov1alpha1.Trench) string {
+	return fmt.Sprintf("%s-%s", cr.Spec.ConfigMapName, cr.ObjectMeta.Name)
+}
+
 type Config struct {
 	VIPs []string `yaml:"vips"`
 }
@@ -77,7 +81,7 @@ func (c *ConfigMap) getData(trench *meridiov1alpha1.Trench) (string, error) {
 func (c *ConfigMap) getSelector(cr *meridiov1alpha1.Trench) client.ObjectKey {
 	return client.ObjectKey{
 		Namespace: cr.ObjectMeta.Namespace,
-		Name:      cr.Spec.ConfigMapName,
+		Name:      getConfigMapName(cr),
 	}
 }
 
@@ -95,7 +99,7 @@ func (c *ConfigMap) getCurrentStatus(ctx context.Context, cr *meridiov1alpha1.Tr
 }
 
 func (c *ConfigMap) insertParamters(cc *corev1.ConfigMap, cr *meridiov1alpha1.Trench) (*corev1.ConfigMap, error) {
-	cc.ObjectMeta.Name = cr.Spec.ConfigMapName
+	cc.ObjectMeta.Name = getConfigMapName(cr)
 	cc.ObjectMeta.Namespace = cr.ObjectMeta.Namespace
 	data, err := c.getData(cr)
 	if err != nil {

--- a/controllers/reconciler/ipam-service.go
+++ b/controllers/reconciler/ipam-service.go
@@ -1,8 +1,6 @@
 package reconciler
 
 import (
-	"fmt"
-
 	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
 	"golang.org/x/net/context"
 	corev1 "k8s.io/api/core/v1"
@@ -19,7 +17,7 @@ const (
 )
 
 func getIPAMServiceName(cr *meridiov1alpha1.Trench) string {
-	return fmt.Sprintf("%s-%s", ipamSvcName, cr.ObjectMeta.Name)
+	return getFullName(cr, ipamSvcName)
 }
 
 type IpamService struct {

--- a/controllers/reconciler/ipam.go
+++ b/controllers/reconciler/ipam.go
@@ -19,7 +19,7 @@ const (
 )
 
 func getIPAMDeploymentName(cr *meridiov1alpha1.Trench) string {
-	return fmt.Sprintf("%s-%s", nameIpam, cr.ObjectMeta.Name)
+	return getFullName(cr, nameIpam)
 }
 
 type IpamDeployment struct {

--- a/controllers/reconciler/ipam.go
+++ b/controllers/reconciler/ipam.go
@@ -13,9 +13,14 @@ import (
 )
 
 const (
+	nameIpam    = "ipam"
 	imageIpam   = "ipam"
 	ipamEnvName = "IPAM_PORT"
 )
+
+func getIPAMDeploymentName(cr *meridiov1alpha1.Trench) string {
+	return fmt.Sprintf("%s-%s", nameIpam, cr.ObjectMeta.Name)
+}
 
 type IpamDeployment struct {
 	currentStatus *appsv1.Deployment
@@ -36,7 +41,12 @@ func (i *IpamDeployment) getEnvVars(cr *meridiov1alpha1.Trench) []corev1.EnvVar 
 func (i *IpamDeployment) insertParamters(dep *appsv1.Deployment, cr *meridiov1alpha1.Trench) *appsv1.Deployment {
 	// if status ipam deployment parameters are specified in the cr, use those
 	// else use the default parameters
+	ipamDeploymentName := getIPAMDeploymentName(cr)
+	dep.ObjectMeta.Name = ipamDeploymentName
 	dep.ObjectMeta.Namespace = cr.ObjectMeta.Namespace
+	dep.ObjectMeta.Labels["app"] = ipamDeploymentName
+	dep.Spec.Selector.MatchLabels["app"] = ipamDeploymentName
+	dep.Spec.Template.ObjectMeta.Labels["app"] = ipamDeploymentName
 	dep.Spec.Template.Spec.Containers[0].Image = fmt.Sprintf("%s/%s/%s:%s", Registry, Organization, imageIpam, Tag)
 	dep.Spec.Template.Spec.Containers[0].ImagePullPolicy = PullPolicy
 	dep.Spec.Template.Spec.Containers[0].LivenessProbe = GetLivenessProbe(cr)
@@ -52,7 +62,7 @@ func (i *IpamDeployment) getModel() (*appsv1.Deployment, error) {
 func (i *IpamDeployment) getSelector(cr *meridiov1alpha1.Trench) client.ObjectKey {
 	return client.ObjectKey{
 		Namespace: cr.ObjectMeta.Namespace,
-		Name:      "ipam",
+		Name:      getIPAMDeploymentName(cr),
 	}
 }
 

--- a/controllers/reconciler/load-balancer.go
+++ b/controllers/reconciler/load-balancer.go
@@ -23,7 +23,7 @@ const (
 )
 
 func getLoadBalancerDeploymentName(cr *meridiov1alpha1.Trench) string {
-	return fmt.Sprintf("%s-%s", lbName, cr.ObjectMeta.Name)
+	return getFullName(cr, lbName)
 }
 
 type LoadBalancer struct {

--- a/controllers/reconciler/load-balancer.go
+++ b/controllers/reconciler/load-balancer.go
@@ -6,18 +6,91 @@ import (
 	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
 	"golang.org/x/net/context"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	lbImage = "load-balancer"
+	lbName                  = "load-balancer"
+	lbImage                 = "load-balancer"
+	lbEnvConfig             = "NSM_CONFIG_MAP_NAME"
+	lbEnvServiceName        = "NSM_SERVICE_NAME"
+	lbEnvNsp                = "NSM_NSP_SERVICE"
+	lbnscEnvNetworkServices = "NSM_NETWORK_SERVICES"
+	lbfeEnvConfig           = "NFE_CONFIG_MAP_NAME"
 )
+
+func getLoadBalancerDeploymentName(cr *meridiov1alpha1.Trench) string {
+	return fmt.Sprintf("%s-%s", lbName, cr.ObjectMeta.Name)
+}
 
 type LoadBalancer struct {
 	currentStatus *appsv1.Deployment
 	desiredStatus *appsv1.Deployment
+}
+
+func (l *LoadBalancer) setEnvVars(dep *appsv1.Deployment, cr *meridiov1alpha1.Trench) {
+	// load-balancer container
+	env := []corev1.EnvVar{
+		{
+			Name:  lbEnvConfig,
+			Value: getConfigMapName(cr),
+		},
+		{
+			Name:  lbEnvServiceName,
+			Value: getLoadBalancerNsName(cr),
+		},
+		{
+			Name:  lbEnvNsp,
+			Value: getNSPService(cr),
+		},
+	}
+	for _, e := range dep.Spec.Template.Spec.Containers[0].Env {
+		// append all hard coded envVars
+		if e.Name == "SPIFFE_ENDPOINT_SOCKET" ||
+			e.Name == "NSM_NAME" ||
+			e.Name == "NSM_NAMESPACE" ||
+			e.Name == "NSM_CONNECT_TO" {
+			env = append(env, e)
+		}
+	}
+	dep.Spec.Template.Spec.Containers[0].Env = env
+	// nsc container
+	env = []corev1.EnvVar{
+		{
+			Name:  lbnscEnvNetworkServices,
+			Value: fmt.Sprintf("vlan://%s.%s.%s/ext-vlan?forwarder=forwarder-vlan", vlanNetworkService, cr.ObjectMeta.Name, cr.ObjectMeta.Namespace),
+		},
+	}
+	for _, e := range dep.Spec.Template.Spec.Containers[1].Env {
+		// append all hard coded envVars
+		if e.Name == "SPIFFE_ENDPOINT_SOCKET" ||
+			e.Name == "NSM_NAME" ||
+			e.Name == "NSM_DIAL_TIMEOUT" ||
+			e.Name == "NSM_REQUEST_TIMEOUT" {
+			env = append(env, e)
+		}
+	}
+	dep.Spec.Template.Spec.Containers[1].Env = env
+	// fe container
+	env = []corev1.EnvVar{
+		{
+			Name:  lbfeEnvConfig,
+			Value: getConfigMapName(cr),
+		},
+	}
+	for _, e := range dep.Spec.Template.Spec.Containers[2].Env {
+		// append all hard coded envVars
+		if e.Name == "NFE_NAMESPACE" ||
+			e.Name == "NFE_GATEWAYS" ||
+			e.Name == "NFE_LOG_BIRD" ||
+			e.Name == "NFE_ECMP" {
+			env = append(env, e)
+		}
+	}
+	dep.Spec.Template.Spec.Containers[2].Env = env
 }
 
 func (l *LoadBalancer) getModel() (*appsv1.Deployment, error) {
@@ -27,18 +100,25 @@ func (l *LoadBalancer) getModel() (*appsv1.Deployment, error) {
 func (l *LoadBalancer) insertParamters(dep *appsv1.Deployment, cr *meridiov1alpha1.Trench) *appsv1.Deployment {
 	// if status load-balancer deployment parameters are specified in the cr, use those
 	// else use the default parameters
+	loadBalancerDeploymentName := getLoadBalancerDeploymentName(cr)
+	dep.ObjectMeta.Name = loadBalancerDeploymentName
 	dep.ObjectMeta.Namespace = cr.ObjectMeta.Namespace
+	dep.ObjectMeta.Labels["app"] = loadBalancerDeploymentName
+	dep.Spec.Selector.MatchLabels["app"] = loadBalancerDeploymentName
+	dep.Spec.Template.ObjectMeta.Labels["app"] = loadBalancerDeploymentName
+	dep.Spec.Template.Spec.ServiceAccountName = getServiceAccountName(cr)
 	dep.Spec.Template.Spec.Containers[0].Image = fmt.Sprintf("%s/%s/%s:%s", Registry, Organization, lbImage, Tag)
 	dep.Spec.Template.Spec.Containers[0].ImagePullPolicy = PullPolicy
 	dep.Spec.Template.Spec.Containers[0].LivenessProbe = GetLivenessProbe(cr)
 	dep.Spec.Template.Spec.Containers[0].ReadinessProbe = GetReadinessProbe(cr)
+	l.setEnvVars(dep, cr)
 	return dep
 }
 
 func (l *LoadBalancer) getSelector(cr *meridiov1alpha1.Trench) client.ObjectKey {
 	return client.ObjectKey{
 		Namespace: cr.ObjectMeta.Namespace,
-		Name:      "load-balancer",
+		Name:      getLoadBalancerDeploymentName(cr),
 	}
 }
 

--- a/controllers/reconciler/models.go
+++ b/controllers/reconciler/models.go
@@ -13,6 +13,8 @@ import (
 )
 
 const (
+	ResourceNamePrefixEnv = "RESOURCE_NAME_PREFIX"
+
 	Registry        = "registry.nordix.org"
 	Organization    = "cloud-native/meridio"
 	OrganizationNsm = "cloud-native/nsm"
@@ -42,6 +44,14 @@ const (
 )
 
 type ipFamily string
+
+func getResourceNamePrefix(cr *meridiov1alpha1.Trench) string {
+	return os.Getenv(ResourceNamePrefixEnv)
+}
+
+func getFullName(cr *meridiov1alpha1.Trench, resourceName string) string {
+	return fmt.Sprintf("%s%s-%s", getResourceNamePrefix(cr), resourceName, cr.ObjectMeta.Name)
+}
 
 func getVips(cr *meridiov1alpha1.Trench) string {
 	ipFamily := IPv4

--- a/controllers/reconciler/models.go
+++ b/controllers/reconciler/models.go
@@ -80,7 +80,23 @@ func getPrefixLength(cr *meridiov1alpha1.Trench) string {
 }
 
 func getVlanNsName(cr *meridiov1alpha1.Trench) string {
-	return fmt.Sprintf("%s.%s", vlanNetworkService, cr.ObjectMeta.Namespace)
+	return fmt.Sprintf("%s.%s.%s", vlanNetworkService, cr.ObjectMeta.Name, cr.ObjectMeta.Namespace)
+}
+
+func getLoadBalancerNsName(cr *meridiov1alpha1.Trench) string {
+	return fmt.Sprintf("%s.%s.%s", lbNetworkService, cr.ObjectMeta.Name, cr.ObjectMeta.Namespace)
+}
+
+func getProxyNsName(cr *meridiov1alpha1.Trench) string {
+	return fmt.Sprintf("%s.%s.%s", proxyNetworkService, cr.ObjectMeta.Name, cr.ObjectMeta.Namespace)
+}
+
+func getNSPService(cr *meridiov1alpha1.Trench) string {
+	return fmt.Sprintf("%s:%d", getNSPServiceName(cr), nspTargetPort)
+}
+
+func getIPAMService(cr *meridiov1alpha1.Trench) string {
+	return fmt.Sprintf("%s:%d", getIPAMServiceName(cr), ipamTargetPort)
 }
 
 func GetReadinessProbe(cr *meridiov1alpha1.Trench) *corev1.Probe {

--- a/controllers/reconciler/nse-vlan.go
+++ b/controllers/reconciler/nse-vlan.go
@@ -23,7 +23,7 @@ const (
 )
 
 func getNSEVLANDeploymentName(cr *meridiov1alpha1.Trench) string {
-	return fmt.Sprintf("%s-%s", nseName, cr.ObjectMeta.Name)
+	return getFullName(cr, nseName)
 }
 
 type NseDeployment struct {

--- a/controllers/reconciler/nsp-service.go
+++ b/controllers/reconciler/nsp-service.go
@@ -1,8 +1,6 @@
 package reconciler
 
 import (
-	"fmt"
-
 	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
 	"golang.org/x/net/context"
 	corev1 "k8s.io/api/core/v1"
@@ -19,7 +17,7 @@ const (
 )
 
 func getNSPServiceName(cr *meridiov1alpha1.Trench) string {
-	return fmt.Sprintf("%s-%s", nspSvcName, cr.ObjectMeta.Name)
+	return getFullName(cr, nspSvcName)
 }
 
 type NspService struct {

--- a/controllers/reconciler/nsp-service.go
+++ b/controllers/reconciler/nsp-service.go
@@ -1,6 +1,8 @@
 package reconciler
 
 import (
+	"fmt"
+
 	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
 	"golang.org/x/net/context"
 	corev1 "k8s.io/api/core/v1"
@@ -15,6 +17,10 @@ const (
 	nspTargetPort = 7778
 	nspSvcName    = "nsp-service"
 )
+
+func getNSPServiceName(cr *meridiov1alpha1.Trench) string {
+	return fmt.Sprintf("%s-%s", nspSvcName, cr.ObjectMeta.Name)
+}
 
 type NspService struct {
 	currentStatus *corev1.Service
@@ -32,16 +38,19 @@ func (i *NspService) getPorts(cr *meridiov1alpha1.Trench) []corev1.ServicePort {
 		},
 	}
 }
+
 func (i *NspService) getSelector(cr *meridiov1alpha1.Trench) client.ObjectKey {
 	return client.ObjectKey{
 		Namespace: cr.ObjectMeta.Namespace,
-		Name:      nspSvcName,
+		Name:      getNSPServiceName(cr),
 	}
 }
 
 func (i *NspService) insertParamters(svc *corev1.Service, cr *meridiov1alpha1.Trench) *corev1.Service {
 	// if status nsp service parameters are specified in the cr, use those
 	// else use the default parameters
+	svc.ObjectMeta.Name = getNSPServiceName(cr)
+	svc.Spec.Selector["app"] = getNSPDeploymentName(cr)
 	svc.ObjectMeta.Namespace = cr.ObjectMeta.Namespace
 	svc.Spec.Ports = i.getPorts(cr)
 	return svc

--- a/controllers/reconciler/nsp.go
+++ b/controllers/reconciler/nsp.go
@@ -19,7 +19,7 @@ const (
 )
 
 func getNSPDeploymentName(cr *meridiov1alpha1.Trench) string {
-	return fmt.Sprintf("%s-%s", nspName, cr.ObjectMeta.Name)
+	return getFullName(cr, nspName)
 }
 
 type NspDeployment struct {

--- a/controllers/reconciler/proxy.go
+++ b/controllers/reconciler/proxy.go
@@ -24,7 +24,7 @@ const (
 )
 
 func getProxyDeploymentName(cr *meridiov1alpha1.Trench) string {
-	return fmt.Sprintf("%s-%s", nameProxy, cr.ObjectMeta.Name)
+	return getFullName(cr, nameProxy)
 }
 
 type Proxy struct {

--- a/controllers/reconciler/role-binding.go
+++ b/controllers/reconciler/role-binding.go
@@ -1,6 +1,8 @@
 package reconciler
 
 import (
+	"fmt"
+
 	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
 	"golang.org/x/net/context"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -13,6 +15,10 @@ const (
 	roleBindingName = "meridio-configuration-role-binding"
 )
 
+func getRoleBindingName(cr *meridiov1alpha1.Trench) string {
+	return fmt.Sprintf("%s-%s", roleBindingName, cr.ObjectMeta.Name)
+}
+
 type RoleBinding struct {
 	currentStatus *rbacv1.RoleBinding
 	desiredStatus *rbacv1.RoleBinding
@@ -23,14 +29,17 @@ func (r *RoleBinding) getModel() (*rbacv1.RoleBinding, error) {
 }
 
 func (r *RoleBinding) insertParamters(role *rbacv1.RoleBinding, cr *meridiov1alpha1.Trench) *rbacv1.RoleBinding {
+	role.ObjectMeta.Name = getRoleBindingName(cr)
 	role.ObjectMeta.Namespace = cr.ObjectMeta.Namespace
+	role.Subjects[0].Name = getServiceAccountName(cr)
+	role.RoleRef.Name = getRoleName(cr)
 	return role
 }
 
 func (r *RoleBinding) getSelector(cr *meridiov1alpha1.Trench) client.ObjectKey {
 	return client.ObjectKey{
 		Namespace: cr.ObjectMeta.Namespace,
-		Name:      roleBindingName,
+		Name:      getRoleBindingName(cr),
 	}
 }
 

--- a/controllers/reconciler/role-binding.go
+++ b/controllers/reconciler/role-binding.go
@@ -1,8 +1,6 @@
 package reconciler
 
 import (
-	"fmt"
-
 	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
 	"golang.org/x/net/context"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -16,7 +14,7 @@ const (
 )
 
 func getRoleBindingName(cr *meridiov1alpha1.Trench) string {
-	return fmt.Sprintf("%s-%s", roleBindingName, cr.ObjectMeta.Name)
+	return getFullName(cr, roleBindingName)
 }
 
 type RoleBinding struct {

--- a/controllers/reconciler/role.go
+++ b/controllers/reconciler/role.go
@@ -1,6 +1,8 @@
 package reconciler
 
 import (
+	"fmt"
+
 	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
 	"golang.org/x/net/context"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -13,6 +15,10 @@ const (
 	roleName = "meridio-configuration-role"
 )
 
+func getRoleName(cr *meridiov1alpha1.Trench) string {
+	return fmt.Sprintf("%s-%s", roleName, cr.ObjectMeta.Name)
+}
+
 type Role struct {
 	currentStatus *rbacv1.Role
 	desiredStatus *rbacv1.Role
@@ -21,7 +27,7 @@ type Role struct {
 func (r *Role) getSelector(cr *meridiov1alpha1.Trench) client.ObjectKey {
 	return client.ObjectKey{
 		Namespace: cr.ObjectMeta.Namespace,
-		Name:      roleName,
+		Name:      getRoleName(cr),
 	}
 }
 
@@ -30,6 +36,7 @@ func (r *Role) getModel() (*rbacv1.Role, error) {
 }
 
 func (r *Role) insertParamters(role *rbacv1.Role, cr *meridiov1alpha1.Trench) *rbacv1.Role {
+	role.ObjectMeta.Name = getRoleName(cr)
 	role.ObjectMeta.Namespace = cr.ObjectMeta.Namespace
 	return role
 }

--- a/controllers/reconciler/role.go
+++ b/controllers/reconciler/role.go
@@ -1,8 +1,6 @@
 package reconciler
 
 import (
-	"fmt"
-
 	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
 	"golang.org/x/net/context"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -16,7 +14,7 @@ const (
 )
 
 func getRoleName(cr *meridiov1alpha1.Trench) string {
-	return fmt.Sprintf("%s-%s", roleName, cr.ObjectMeta.Name)
+	return getFullName(cr, roleName)
 }
 
 type Role struct {

--- a/controllers/reconciler/service-account.go
+++ b/controllers/reconciler/service-account.go
@@ -1,8 +1,6 @@
 package reconciler
 
 import (
-	"fmt"
-
 	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
 	"golang.org/x/net/context"
 	corev1 "k8s.io/api/core/v1"
@@ -15,7 +13,7 @@ import (
 const serviceAccountName = "meridio"
 
 func getServiceAccountName(cr *meridiov1alpha1.Trench) string {
-	return fmt.Sprintf("%s-%s", serviceAccountName, cr.ObjectMeta.Name)
+	return getFullName(cr, serviceAccountName)
 }
 
 type ServiceAccount struct {

--- a/controllers/reconciler/service-account.go
+++ b/controllers/reconciler/service-account.go
@@ -1,6 +1,8 @@
 package reconciler
 
 import (
+	"fmt"
+
 	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
 	"golang.org/x/net/context"
 	corev1 "k8s.io/api/core/v1"
@@ -12,6 +14,10 @@ import (
 
 const serviceAccountName = "meridio"
 
+func getServiceAccountName(cr *meridiov1alpha1.Trench) string {
+	return fmt.Sprintf("%s-%s", serviceAccountName, cr.ObjectMeta.Name)
+}
+
 type ServiceAccount struct {
 	currentStatus *corev1.ServiceAccount
 	desiredStatus *corev1.ServiceAccount
@@ -20,11 +26,12 @@ type ServiceAccount struct {
 func (sa *ServiceAccount) getSelector(cr *meridiov1alpha1.Trench) client.ObjectKey {
 	return client.ObjectKey{
 		Namespace: cr.ObjectMeta.Namespace,
-		Name:      serviceAccountName,
+		Name:      getServiceAccountName(cr),
 	}
 }
 
 func (sa *ServiceAccount) insertParamters(role *corev1.ServiceAccount, cr *meridiov1alpha1.Trench) *corev1.ServiceAccount {
+	role.ObjectMeta.Name = getServiceAccountName(cr)
 	role.ObjectMeta.Namespace = cr.ObjectMeta.Namespace
 	return role
 }
@@ -45,7 +52,7 @@ func (sa *ServiceAccount) getCurrentStatus(ctx context.Context, cr *meridiov1alp
 func (sa *ServiceAccount) getDesiredStatus(cr *meridiov1alpha1.Trench) error {
 	sa.desiredStatus = &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      serviceAccountName,
+			Name:      getServiceAccountName(cr),
 			Namespace: cr.ObjectMeta.Namespace,
 		},
 	}

--- a/deployment/load-balancer.yaml
+++ b/deployment/load-balancer.yaml
@@ -90,7 +90,7 @@ spec:
           securityContext:
             privileged: true
         - name: nsc
-          image: registry.nordix.org/cloud-native/nsm/cmd-nsc:latest
+          image: registry.nordix.org/cloud-native/nsm/cmd-nsc:latest-dns-fix
           imagePullPolicy: IfNotPresent
           env:
             - name: SPIFFE_ENDPOINT_SOCKET
@@ -116,14 +116,18 @@ spec:
           image: registry.nordix.org/cloud-native/meridio/frontend:latest
           imagePullPolicy: IfNotPresent
           env:
-            - name: NFE_VIPS
-              value: 20.0.0.1/32
+            - name: NFE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: NFE_GATEWAYS
-              value: 169.254.100.254/24,fe80::beef/64,169.254.100.253/24,fe80::beee/64
+              value: 169.254.100.150/24,100:100::150/64
             - name: NFE_LOG_BIRD
               value: "true"
             - name: NFE_ECMP
               value: "true"
+            - name: NFE_CONFIG_MAP_NAME
+              value: meridio-configuration
           securityContext:
             privileged: true
       volumes:

--- a/deployment/proxy.yaml
+++ b/deployment/proxy.yaml
@@ -71,8 +71,6 @@ spec:
               value: unix:///var/lib/networkservicemesh/nsm.io.sock
             - name: NSM_SERVICE_NAME
               value: proxy.load-balancer.default
-            - name: NSM_VIPS
-              value: 20.0.0.1/32
             - name: NSM_SUBNET_POOLS
               value: 172.16.0.0/16
             - name: NSM_SUBNET_PREFIX_LENGTHS
@@ -81,8 +79,6 @@ spec:
               value: ipam-service:7777
             - name: NSM_NETWORK_SERVICE_NAME
               value: load-balancer.default
-            - name: NSM_NSP_SERVICE
-              value: nsp-service:7778
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets


### PR DESCRIPTION
The name of the resources has been modified to correspond to the latest Meridio version. Now, each resource name includes the name of the trench it belongs to. The environment variables are also compliant to the latest Meridio version by using the name of the trench, and the namespace of the trench.

In addition, the missing LB environment variables have been added.

With these changes, and the VLAN ID as parameter, It should be possible multiple trenches at the same time in the same cluster.

