### PR TITLE
Remove redundant trench label from gateway controller

### DIFF
--- a/api/v1alpha1/gateway_types.go
+++ b/api/v1alpha1/gateway_types.go
@@ -45,7 +45,6 @@ type GatewayStatus struct {
 //+kubebuilder:printcolumn:name="address",type=string,JSONPath=`.spec.address`
 //+kubebuilder:printcolumn:name="protocol",type=string,JSONPath=`.spec.protocol`
 //+kubebuilder:printcolumn:name="BFD",type=string,JSONPath=`.spec.bfd`
-//+kubebuilder:printcolumn:name="trench",type=string,JSONPath=`.metadata.labels.trench`
 //+kubebuilder:printcolumn:name="attractor",type=string,JSONPath=`.metadata.labels.attractor`
 //+kubebuilder:printcolumn:name="status",type=string,JSONPath=`.status.status`
 //+kubebuilder:printcolumn:name="message",type=string,JSONPath=`.status.message`

--- a/api/v1alpha1/gateway_webhook.go
+++ b/api/v1alpha1/gateway_webhook.go
@@ -88,9 +88,6 @@ func (r *Gateway) ValidateDelete() error {
 
 func (r *Gateway) validateLabels() field.ErrorList {
 	var allErrs field.ErrorList
-	if value, ok := r.ObjectMeta.Labels["trench"]; !ok {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata").Child("labels").Child("trench"), value, "gateway must have a trench label"))
-	}
 	if value, ok := r.ObjectMeta.Labels["attractor"]; !ok {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata").Child("labels").Child("attractor"), value, "gateway must have a attractor label"))
 	}
@@ -139,17 +136,11 @@ func (r *Gateway) validateUpdate(oldObj runtime.Object) error {
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a gateway got got a %T", old))
 	}
-	trenchNew := r.ObjectMeta.Labels["trench"]
-	trenchOld := old.ObjectMeta.Labels["trench"]
-	if trenchNew != trenchOld {
-		return apierrors.NewForbidden(r.GroupResource(),
-			r.Name, field.Forbidden(field.NewPath("metadata", "labels", "trench"), "update on trench label trench is forbidden"))
-	}
 	attrNew := r.ObjectMeta.Labels["attractor"]
 	attrOld := old.ObjectMeta.Labels["attractor"]
 	if attrNew != attrOld {
 		return apierrors.NewForbidden(r.GroupResource(),
-			r.Name, field.Forbidden(field.NewPath("metadata", "labels", "attractor"), "update on attractor label trench is forbidden"))
+			r.Name, field.Forbidden(field.NewPath("metadata", "labels", "attractor"), "update on attractor label is forbidden"))
 	}
 
 	return nil

--- a/config/crd/bases/meridio.nordix.org_gateways.yaml
+++ b/config/crd/bases/meridio.nordix.org_gateways.yaml
@@ -26,9 +26,6 @@ spec:
     - jsonPath: .spec.bfd
       name: BFD
       type: string
-    - jsonPath: .metadata.labels.trench
-      name: trench
-      type: string
     - jsonPath: .metadata.labels.attractor
       name: attractor
       type: string

--- a/controllers/attractor/attractor_controller.go
+++ b/controllers/attractor/attractor_controller.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/go-logr/logr"
@@ -62,13 +61,7 @@ func (r *AttractorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	err := r.Get(ctx, req.NamespacedName, attr)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			if err != nil {
-				return ctrl.Result{}, nil
-			}
-			return reconcile.Result{}, nil
-		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	currentAttr := attr.DeepCopy()
 	attr.Status = meridiov1alpha1.AttractorStatus{}

--- a/controllers/attractor/configmap.go
+++ b/controllers/attractor/configmap.go
@@ -143,9 +143,11 @@ func (c *ConfigMap) getDesiredStatus(al *meridiov1alpha1.GatewayList, vl *meridi
 	return configmap, nil
 }
 
+// list all existing gateways expected by attractor
 func (c *ConfigMap) listGatewaysByLabel() (*meridiov1alpha1.GatewayList, error) {
 	gatewayList := &meridiov1alpha1.GatewayList{}
 	for _, gwName := range c.attr.Spec.Gateways {
+		// iterating 'gateway' field in attractor, find gateway by name
 		gateway := &meridiov1alpha1.Gateway{}
 		err := c.exec.GetObject(client.ObjectKey{
 			Name:      gwName,
@@ -157,10 +159,9 @@ func (c *ConfigMap) listGatewaysByLabel() (*meridiov1alpha1.GatewayList, error) 
 			}
 			return nil, err
 		}
-		// referred gateway should also match the attractor label
+		// only append the gateways having the attractor label same as this attractor to the return gateway list
 		sel := labels.Set{
 			"attractor": c.attr.ObjectMeta.Name,
-			"trench":    c.trench.ObjectMeta.Name,
 		}
 		gatewayLabels := gateway.ObjectMeta.Labels
 		if gatewayLabels == nil {
@@ -280,6 +281,8 @@ func (c *ConfigMap) getAction() (common.Action, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// update owner of the gateways
 	if cs == nil {
 		ds, err := c.getDesiredStatus(al, vl)
 		if err != nil {

--- a/readme.md
+++ b/readme.md
@@ -104,7 +104,7 @@ attractor.meridio.nordix.org/attr1   100      eth0      ["gateway1","gateway3"] 
 
 ### Gateway
 
-A gateway should specify its owner reference attractor and trench by `attractor` and `trench` label. Likewise, they are immutable. If either the attractor or the trench is not found in the cluster, the status of gateway will be verdicted as `disengaged`, and attractor will not use it. Similarly, the status will not be updated if the attractor is created afterwards. There is a limitation of order also stands for attractors and gateways. Attractors should be created in advance than the gateways.
+A gateway should specify its owner reference attractor and trench by `attractor` label. Likewise, this label is immutable. If the attractor is not found in the cluster, the status of gateway resource will be verdicted as `disengaged`, and no attractor will not use it. Similarly, the status will not be updated if the attractor is created afterwards. There is a limitation of order also stands for attractors and gateways. Attractors should be created in advance than the gateways.
 
 In gateway custom resource `address` is a mandatory parameter.
 `bfd` is set to false by default, and that is the only supported value too.
@@ -120,9 +120,9 @@ The following resources should be found
 
 ```bash
 kubectl get gateways
-NAME                                  ADDRESS   PROTOCOL   BFD     TRENCH     ATTRACTOR   STATUS    MESSAGE
-gateway.meridio.nordix.org/gateway1   2.3.4.5   bgp        false   trench-a   attr1       engaged
-gateway.meridio.nordix.org/gateway2   1000::1   bgp        false   trench-a   attr1       engaged
+NAME                                  ADDRESS   PROTOCOL   BFD     ATTRACTOR   STATUS    MESSAGE
+gateway.meridio.nordix.org/gateway1   2.3.4.5   bgp        false   attr1       engaged
+gateway.meridio.nordix.org/gateway2   1000::1   bgp        false   attr1       engaged
 ```
 
 And the *GW-IN-USE* coloumn of the attractor should be updated with the existing expected gateways. Shown as below
@@ -132,7 +132,7 @@ NAME                                 VLANID   VLANITF   GATEWAYS                
 attractor.meridio.nordix.org/attr1   100      eth0      ["gateway1","gateway2"]   ["gateway1","gateway2"]   ["vip1","vip2"]                 trench-a   engaged
 ```
 
-#### Vip
+### Vip
 
 A vip should belong to one `attractor` and `trench`, which specified with labels, same as gateway. Also they need to follow an order that trench and attractor are created before the vips. Otherwise the status will be verdicted as `disengaged`, and cannot be revised if labeled trench or attractor are created afterwards.
 


### PR DESCRIPTION
The trench label in gateway resource is only used for redundant
validation. Owner reference is only set by attractor label.
Removing it to make the dependencies clearer.