### PR TITLE
add ip-family in trench CRD

### DIFF
--- a/api/v1alpha1/trench_types.go
+++ b/api/v1alpha1/trench_types.go
@@ -26,8 +26,7 @@ import (
 
 // TrenchSpec defines the desired state of Trench
 type TrenchSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
+	IPFamily string `json:"ip-family,omitempty"`
 }
 
 // TrenchStatus defines the observed state of Trench
@@ -38,7 +37,7 @@ type TrenchStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-
+//+kubebuilder:printcolumn:name="IP-Family",type=string,JSONPath=`.spec.ip-family`
 // Trench is the Schema for the trenches API
 type Trench struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -1,5 +1,7 @@
 package v1alpha1
 
+import "errors"
+
 type Status struct {
 	NoPhase string
 	Error   string
@@ -36,3 +38,20 @@ type Protocol string
 
 var BFD Protocol = "static"
 var BGP Protocol = "bgp"
+
+type ipFamily string
+
+var (
+	IPv4      ipFamily = "ipv4"
+	IPv6      ipFamily = "ipv6"
+	Dualstack ipFamily = "dualstack"
+)
+
+func (f ipFamily) IsValid() error {
+	switch f {
+	case IPv4, IPv6, Dualstack:
+		return nil
+	default:
+		return errors.New("invalid ip-family type")
+	}
+}

--- a/config/crd/bases/meridio.nordix.org_trenches.yaml
+++ b/config/crd/bases/meridio.nordix.org_trenches.yaml
@@ -16,7 +16,11 @@ spec:
     singular: trench
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.ip-family
+      name: IP-Family
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Trench is the Schema for the trenches API
@@ -35,6 +39,9 @@ spec:
             type: object
           spec:
             description: TrenchSpec defines the desired state of Trench
+            properties:
+              ip-family:
+                type: string
             type: object
           status:
             description: TrenchStatus defines the observed state of Trench

--- a/config/samples/trenches.yaml
+++ b/config/samples/trenches.yaml
@@ -7,3 +7,5 @@ apiVersion: meridio.nordix.org/v1alpha1
 kind: Trench
 metadata:
   name: trench-b
+spec:
+  ip-family: ipv4

--- a/controllers/common/const.go
+++ b/controllers/common/const.go
@@ -18,10 +18,6 @@ const (
 	Tag             = "latest"
 	PullPolicy      = "IfNotPresent"
 
-	IPv4      ipFamily = "ipv4"
-	IPv6      ipFamily = "ipv6"
-	Dualstack ipFamily = "dualstack"
-
 	subnetPoolIpv4   = "172.16.0.0/16"
 	subnetPoolIpv6   = "fd00::/48"
 	prefixLengthIpv4 = "24"

--- a/controllers/common/models.go
+++ b/controllers/common/models.go
@@ -13,28 +13,24 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
-type ipFamily string
-
 func GetSubnetPool(cr *meridiov1alpha1.Trench) string {
-	ipFamily := IPv4
-	if ipFamily == IPv4 {
-		return subnetPoolIpv4
-	} else if ipFamily == IPv6 {
-		return subnetPoolIpv6
-	} else if ipFamily == Dualstack {
+	if cr.Spec.IPFamily == string(meridiov1alpha1.Dualstack) {
 		return fmt.Sprintf("%s,%s", subnetPoolIpv4, subnetPoolIpv6)
+	} else if cr.Spec.IPFamily == string(meridiov1alpha1.IPv4) {
+		return subnetPoolIpv4
+	} else if cr.Spec.IPFamily == string(meridiov1alpha1.IPv6) {
+		return subnetPoolIpv6
 	}
 	return ""
 }
 
 func GetPrefixLength(cr *meridiov1alpha1.Trench) string {
-	ipFamily := IPv4
-	if ipFamily == IPv4 {
-		return prefixLengthIpv4
-	} else if ipFamily == IPv6 {
-		return prefixLengthIpv6
-	} else if ipFamily == Dualstack {
+	if cr.Spec.IPFamily == string(meridiov1alpha1.Dualstack) {
 		return fmt.Sprintf("%s,%s", prefixLengthIpv4, prefixLengthIpv6)
+	} else if cr.Spec.IPFamily == string(meridiov1alpha1.IPv4) {
+		return prefixLengthIpv4
+	} else if cr.Spec.IPFamily == string(meridiov1alpha1.IPv6) {
+		return prefixLengthIpv6
 	}
 	return ""
 }

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ make deploy IMG="localhost:5000/meridio/meridio-operator:v0.0.1"
 
 ### Trench
 
-A trench resource does not have any parameters in its specification.
+A trench configures the IP family. The default value of `ip-family` is 'dualstack', but it can also be 'ipv4' or 'ipv6'.
 Deploying a trench spawns the IPAM, NSP, Proxy, and needed role, role-binding and service accounts. The resouces created by a trench will be suffixed with the trench's name.
 
 ```bash
@@ -47,8 +47,8 @@ After applying, you should able to see the following instances in the cluster
 
 ```bash
 kubectl get trench
-NAME       AGE
-trench-a   1m
+NAME                                 IP-FAMILY
+trench.meridio.nordix.org/trench-a   dualstack
 
 kubectl get all
 NAME                                  READY   STATUS        RESTARTS   AGE


### PR DESCRIPTION
The proxy deployment will take the parameter to configure subnet pool and prefix length
- It's an optional parameter
- Default is dualstack
- Webhook validates the value to be ipv4/ipv6/dualstack(case-insensitive)