### PR TITLE
Add NSE Vlan prefix in attractor CRD

### DIFF
--- a/api/v1alpha1/attractor_types.go
+++ b/api/v1alpha1/attractor_types.go
@@ -29,6 +29,10 @@ type AttractorSpec struct {
 	VlanInterface string `json:"vlan-interface"`
 	// vlan ID, cannot be updated
 	VlanID int `json:"vlan-id"`
+	// vlan ipv4 prefix
+	VlanPrefixIPv4 string `json:"vlan-ipv4-prefix"`
+	// vlan ipv6 prefix
+	VlanPrefixIPv6 string `json:"vlan-ipv6-prefix"`
 	// gateways that attractor expect to use
 	Gateways []string `json:"gateways,omitempty"`
 	// vips that attractor expect to use

--- a/api/v1alpha1/attractor_webhook.go
+++ b/api/v1alpha1/attractor_webhook.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"net"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -86,6 +87,16 @@ func (r *Attractor) validateAttractor() error {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata").Child("labels"), r.ObjectMeta.Labels, err.Error()))
 	}
 
+	_, _, err := net.ParseCIDR(r.Spec.VlanPrefixIPv4)
+	if err != nil {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("vlan-ipv4-prefix"), r.Spec.VlanPrefixIPv4, err.Error()))
+	}
+
+	_, _, err = net.ParseCIDR(r.Spec.VlanPrefixIPv6)
+	if err != nil {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("vlan-ipv6-prefix"), r.Spec.VlanPrefixIPv6, err.Error()))
+	}
+
 	if len(allErrs) == 0 {
 		return nil
 	}
@@ -121,7 +132,17 @@ func (r *Attractor) validateUpdate(old runtime.Object) error {
 
 	if r.Spec.VlanInterface != attrOld.Spec.VlanInterface {
 		return apierrors.NewForbidden(r.GroupResource(),
-			r.Name, field.Forbidden(field.NewPath("metadata", "vlan-interface"), "update on vlan interface is forbidden"))
+			r.Name, field.Forbidden(field.NewPath("spec", "vlan-interface"), "update on vlan interface is forbidden"))
+	}
+
+	if r.Spec.VlanPrefixIPv4 != attrOld.Spec.VlanPrefixIPv4 {
+		return apierrors.NewForbidden(r.GroupResource(),
+			r.Name, field.Forbidden(field.NewPath("spec", "vlan-ipv4-prefix"), "update on vlan prefix is forbidden"))
+	}
+
+	if r.Spec.VlanPrefixIPv6 != attrOld.Spec.VlanPrefixIPv6 {
+		return apierrors.NewForbidden(r.GroupResource(),
+			r.Name, field.Forbidden(field.NewPath("spec", "vlan-ipv6-prefix"), "update on vlan prefix is forbidden"))
 	}
 	return nil
 }

--- a/api/v1alpha1/vip_webhook.go
+++ b/api/v1alpha1/vip_webhook.go
@@ -89,10 +89,6 @@ func (r *Vip) validateVip() error {
 }
 
 func (r *Vip) validateAddresses() error {
-	_, _, err := net.ParseCIDR(r.Spec.Address)
-	if err != nil {
-		return err
-	}
 	ip, ipnet, err := net.ParseCIDR(r.Spec.Address)
 	if err != nil {
 		return err

--- a/config/crd/bases/meridio.nordix.org_attractors.yaml
+++ b/config/crd/bases/meridio.nordix.org_attractors.yaml
@@ -81,9 +81,17 @@ spec:
               vlan-interface:
                 description: vlan interface, cannot be updated
                 type: string
+              vlan-ipv4-prefix:
+                description: vlan ipv4 prefix
+                type: string
+              vlan-ipv6-prefix:
+                description: vlan ipv6 prefix
+                type: string
             required:
             - vlan-id
             - vlan-interface
+            - vlan-ipv4-prefix
+            - vlan-ipv6-prefix
             type: object
           status:
             description: AttractorStatus defines the observed state of Attractor

--- a/config/samples/attractors.yaml
+++ b/config/samples/attractors.yaml
@@ -14,6 +14,8 @@ spec:
   replicas: 1
   vlan-id: 100
   vlan-interface: eth0
+  vlan-ipv4-prefix: 169.254.100.0/24
+  vlan-ipv6-prefix: 100:100::/64
 ---
 apiVersion: meridio.nordix.org/v1alpha1
 kind: Attractor
@@ -29,3 +31,5 @@ spec:
   replicas: 1
   vlan-id: 101
   vlan-interface: eth0
+  vlan-ipv4-prefix: 169.254.100.0/24
+  vlan-ipv6-prefix: 100:100::/64

--- a/config/samples/meridio_v1alpha1_attractor.yaml
+++ b/config/samples/meridio_v1alpha1_attractor.yaml
@@ -14,3 +14,5 @@ spec:
   replicas: 1
   vlan-id: 100
   vlan-interface: eth0
+  vlan-ipv4-prefix: 169.254.100.0/28
+  vlan-ipv6-prefix: 100:100::/64

--- a/controllers/attractor/nse-vlan.go
+++ b/controllers/attractor/nse-vlan.go
@@ -19,9 +19,6 @@ const (
 	nseEnvSerive   = "NSE_SERVICE_NAME"
 	nseEnvPrefixV4 = "NSE_CIDR_PREFIX"
 	nseEnvPrefixV6 = "NSE_IPV6_PREFIX"
-
-	vlanPrefixIPv4 = "169.254.100.0/24"
-	vlanPrefixIPv6 = "100:100::/64"
 )
 
 type NseDeployment struct {
@@ -61,11 +58,11 @@ func (i *NseDeployment) getEnvVars(con corev1.Container) []corev1.EnvVar {
 		},
 		{
 			Name:  nseEnvPrefixV4,
-			Value: vlanPrefixIPv4,
+			Value: i.attractor.Spec.VlanPrefixIPv4,
 		},
 		{
 			Name:  nseEnvPrefixV6,
-			Value: vlanPrefixIPv6,
+			Value: i.attractor.Spec.VlanPrefixIPv6,
 		},
 	}
 


### PR DESCRIPTION
- parameters are mandatory and immutable
- prefix is validated in format