### PR TITLE
Remove the attractor label from the vip resource

### DIFF
--- a/api/v1alpha1/vip_webhook.go
+++ b/api/v1alpha1/vip_webhook.go
@@ -114,11 +114,5 @@ func (r *Vip) validateLabelUpdate(oldObj runtime.Object) error {
 		return apierrors.NewForbidden(r.GroupResource(),
 			r.Name, field.Forbidden(field.NewPath("metadata", "labels", "trench"), "update on vip label trench is forbidden"))
 	}
-	new = r.ObjectMeta.Labels["attractor"]
-	old = vipOld.ObjectMeta.Labels["attractor"]
-	if new != old {
-		return apierrors.NewForbidden(r.GroupResource(),
-			r.Name, field.Forbidden(field.NewPath("metadata", "labels", "attractor"), "update on vip label attractor is forbidden"))
-	}
 	return nil
 }

--- a/config/crd/bases/meridio.nordix.org_gateways.yaml
+++ b/config/crd/bases/meridio.nordix.org_gateways.yaml
@@ -79,7 +79,7 @@ spec:
                     format: int32
                     type: integer
                   local-port:
-                    default: false
+                    default: 179
                     description: BGP listening port of the frontend. Default 179
                     type: integer
                   remote-asn:

--- a/config/samples/meridio_v1alpha1_vip.yaml
+++ b/config/samples/meridio_v1alpha1_vip.yaml
@@ -3,7 +3,6 @@ kind: Vip
 metadata:
   labels:
     trench: trench-a
-    attractor: attr1
   name: vip1
 spec:
   address: "20.0.0.1/32"
@@ -13,7 +12,6 @@ kind: Vip
 metadata:
   labels:
     trench: trench-a
-    attractor: attr1
   name: vip2
 spec:
   address: "10.0.0.1/32"

--- a/config/samples/vips.yaml
+++ b/config/samples/vips.yaml
@@ -3,7 +3,6 @@ kind: Vip
 metadata:
   labels:
     trench: trench-a
-    attractor: attr1
   name: vip1
 spec:
   address: "20.0.0.1/30"
@@ -13,7 +12,6 @@ kind: Vip
 metadata:
   labels:
     trench: trench-a
-    attractor: attr1
   name: vip2
 spec:
   address: "10.0.0.1/28"
@@ -23,7 +21,6 @@ kind: Vip
 metadata:
   labels:
     trench: trench-b
-    attractor: attr2
   name: vip3
 spec:
   address: "2000::1/126"

--- a/controllers/attractor/attractor_controller.go
+++ b/controllers/attractor/attractor_controller.go
@@ -159,7 +159,6 @@ func validateAttractor(e *common.Executor, attr *meridiov1alpha1.Attractor) (*me
 
 func getAttractorActions(e *common.Executor, new, old *meridiov1alpha1.Attractor) []common.Action {
 	var actions []common.Action
-	// set the status for the vip
 	attrnsname := common.NsName(new.ObjectMeta)
 	if !equality.Semantic.DeepEqual(new.Status, old.Status) {
 		actions = append(actions, common.NewUpdateStatusAction(new, fmt.Sprintf("update %s status: %v", attrnsname, new.Status.LbFe)))

--- a/controllers/common/action.go
+++ b/controllers/common/action.go
@@ -61,8 +61,8 @@ func (e *Executor) GetObject(selector client.ObjectKey, obj client.Object) error
 	return e.client.Get(e.ctx, selector, obj)
 }
 
-func (e *Executor) ListObject(obj client.ObjectList, opts client.ListOption) error {
-	return e.client.List(e.ctx, obj, opts)
+func (e *Executor) ListObject(obj client.ObjectList, opts ...client.ListOption) error {
+	return e.client.List(e.ctx, obj, opts...)
 }
 
 func (e *Executor) RunAll(actions []Action) error {

--- a/controllers/trench/configmap.go
+++ b/controllers/trench/configmap.go
@@ -1,0 +1,208 @@
+package trench
+
+import (
+	"fmt"
+	"reflect"
+
+	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
+	"github.com/nordix/meridio-operator/controllers/common"
+	meridioconfig "github.com/nordix/meridio-operator/controllers/config"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"gopkg.in/yaml.v2"
+)
+
+type ConfigMap struct {
+	trench *meridiov1alpha1.Trench
+	exec   *common.Executor
+}
+
+func NewConfigMap(e *common.Executor, t *meridiov1alpha1.Trench) *ConfigMap {
+	l := &ConfigMap{
+		trench: t.DeepCopy(),
+		exec:   e,
+	}
+	return l
+}
+
+func diffConfigContent(mapA, mapB map[string]string) (bool, string) {
+	vip, vipmsg := diffVips(mapA[meridioconfig.VipsConfigKey], mapB[meridioconfig.VipsConfigKey])
+	return vip, vipmsg
+}
+
+func diffVips(cc, cd string) (bool, string) {
+	configcd, err := meridioconfig.UnmarshalVipConfig(cd)
+	if err != nil {
+		return true, fmt.Sprintf("unmarshal desired vip error %s", err)
+	}
+	mapcd := meridioconfig.MakeMapFromVipList(configcd)
+	configcc, err := meridioconfig.UnmarshalVipConfig(cc)
+	if err != nil {
+		return true, fmt.Sprintf("unmarshal current vip error %s", err)
+	}
+	mapcc := meridioconfig.MakeMapFromVipList(configcc)
+	return vipItemsDifferent(mapcc, mapcd)
+}
+
+func vipItemsDifferent(mapA, mapB map[string]meridioconfig.Vip) (bool, string) {
+	for name := range mapA {
+		if _, ok := mapB[name]; !ok {
+			return true, fmt.Sprintf("%s needs updated", name)
+		}
+	}
+	for name := range mapB {
+		if _, ok := mapA[name]; !ok {
+			return true, fmt.Sprintf("%s needs updated", name)
+		}
+	}
+	for key, value := range mapA {
+		if !reflect.DeepEqual(mapB[key], value) {
+			return true, fmt.Sprintf("%s needs updated", key)
+		}
+	}
+	return false, ""
+}
+
+func (c *ConfigMap) getSelector() client.ObjectKey {
+	return client.ObjectKey{
+		Namespace: c.trench.ObjectMeta.Namespace,
+		Name:      common.ConfigMapName(c.trench),
+	}
+}
+
+func (c *ConfigMap) getCurrentStatus() (*corev1.ConfigMap, error) {
+	currentState := &corev1.ConfigMap{}
+	err := c.exec.GetObject(c.getSelector(), currentState)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return currentState, nil
+}
+
+func (c *ConfigMap) listVipsByLabel() (*meridiov1alpha1.VipList, error) {
+	vipList := &meridiov1alpha1.VipList{}
+
+	err := c.exec.ListObject(vipList, client.InNamespace(c.trench.ObjectMeta.Namespace), client.MatchingLabels{"trench": c.trench.ObjectMeta.Name})
+	if err != nil {
+		return nil, client.IgnoreNotFound(err)
+	}
+	return vipList, nil
+}
+
+func (c *ConfigMap) listAttractorsByLabel() (*meridiov1alpha1.AttractorList, error) {
+	lst := &meridiov1alpha1.AttractorList{}
+
+	err := c.exec.ListObject(lst, client.InNamespace(c.trench.ObjectMeta.Namespace), client.MatchingLabels{"trench": c.trench.ObjectMeta.Name})
+	if err != nil {
+		return nil, client.IgnoreNotFound(err)
+	}
+	return lst, nil
+}
+
+func (c *ConfigMap) getDesiredStatus(vl []meridiov1alpha1.Vip) (*corev1.ConfigMap, error) {
+	configmap := &corev1.ConfigMap{}
+	configmap.ObjectMeta.Name = common.ConfigMapName(c.trench)
+	configmap.ObjectMeta.Namespace = c.trench.ObjectMeta.Namespace
+
+	vdata, err := getVipData(vl)
+	if err != nil {
+		return nil, err
+	}
+	configmap.Data = map[string]string{
+		meridioconfig.VipsConfigKey: vdata,
+	}
+	return configmap, nil
+}
+
+func (c *ConfigMap) getReconciledDesiredStatus(vl []meridiov1alpha1.Vip, cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	vdata, err := getVipData(vl)
+	if err != nil {
+		return nil, err
+	}
+	ret := cm.DeepCopy()
+	ret.Data[meridioconfig.VipsConfigKey] = vdata
+	return ret, nil
+}
+
+func getVipData(vips []meridiov1alpha1.Vip) (string, error) {
+	config := &meridioconfig.VipConfig{}
+	for _, vp := range vips {
+		if vp.Status.Status != meridiov1alpha1.Engaged {
+			continue
+		}
+		config.Vips = append(config.Vips, meridioconfig.Vip{
+			Name:    vp.ObjectMeta.Name,
+			Address: vp.Spec.Address,
+		})
+	}
+	configYAML, err := yaml.Marshal(config)
+	if err != nil {
+		return "", fmt.Errorf("error yaml.Marshal: %s", err)
+	}
+	return string(configYAML), nil
+}
+
+func (c *ConfigMap) getAction() ([]common.Action, error) {
+	var actions []common.Action
+	// get action to update/create the configmap
+	cs, err := c.getCurrentStatus()
+	if err != nil {
+		return nil, err
+	}
+	elem := common.ConfigMapName(c.trench)
+
+	// get attractors with trench label
+	attrs, err := c.listAttractorsByLabel()
+	if err != nil {
+		return nil, err
+	}
+	// get vips with trench label
+	vips, err := c.listVipsByLabel()
+	if err != nil {
+		return nil, err
+	}
+	// make a index map for vip for looking up
+	vipIndexMap := func(vips *meridiov1alpha1.VipList) map[string]int {
+		im := make(map[string]int)
+		for i, v := range vips.Items {
+			im[v.ObjectMeta.Name] = i
+		}
+		return im
+	}(vips)
+
+	// for each attractor, search the expected vips exists in the current created vip list or not
+	for _, attr := range attrs.Items {
+		var vips4attr []meridiov1alpha1.Vip
+		for _, v := range attr.Spec.Vips {
+			// if index can be found in the index map
+			if ind, ok := vipIndexMap[v]; ok {
+				vips4attr = append(vips4attr, vips.Items[ind])
+			}
+		}
+		// create configmap if not exist, or update configmap
+		if cs == nil {
+			ds, err := c.getDesiredStatus(nil)
+			if err != nil {
+				return nil, err
+			}
+			c.exec.LogInfo(fmt.Sprintf("add action: create %s", elem))
+			actions = append(actions, common.NewCreateAction(ds, fmt.Sprintf("create %s", elem)))
+		} else {
+			ds, err := c.getReconciledDesiredStatus(vips4attr, cs)
+			if err != nil {
+				return nil, err
+			}
+			if diff, diffmsg := diffConfigContent(cs.Data, ds.Data); diff {
+				c.exec.LogInfo(fmt.Sprintf("add action: update %s", elem))
+				actions = append(actions, common.NewUpdateAction(ds, fmt.Sprintf("%s, %s", fmt.Sprintf("update %s", elem), diffmsg)))
+			}
+		}
+	}
+
+	return actions, nil
+}

--- a/controllers/trench/resources.go
+++ b/controllers/trench/resources.go
@@ -8,8 +8,7 @@ import (
 )
 
 type Resources interface {
-	getAction(e *common.Executor) (common.Action, error)
-	getModel() error
+	getAction() ([]common.Action, error)
 }
 
 type Meridio struct {
@@ -21,41 +20,43 @@ type Meridio struct {
 	nspDeployment  *NspDeployment
 	nspService     *NspService
 	proxy          *Proxy
+	configmap      *ConfigMap
 }
 
-func NewMeridio(trench *meridiov1alpha1.Trench) (*Meridio, error) {
-	ipamsvc, err := NewIPAMSvc(trench)
+func NewMeridio(e *common.Executor, trench *meridiov1alpha1.Trench) (*Meridio, error) {
+	ipamsvc, err := NewIPAMSvc(e, trench)
 	if err != nil {
 		return nil, err
 	}
-	ipam, err := NewIPAM(trench)
+	ipam, err := NewIPAM(e, trench)
 	if err != nil {
 		return nil, err
 	}
-	sa, err := NewServiceAccount(trench)
+	sa, err := NewServiceAccount(e, trench)
 	if err != nil {
 		return nil, err
 	}
-	role, err := NewRole(trench)
+	role, err := NewRole(e, trench)
 	if err != nil {
 		return nil, err
 	}
-	rb, err := NewRoleBinding(trench)
+	rb, err := NewRoleBinding(e, trench)
 	if err != nil {
 		return nil, err
 	}
-	nspd, err := NewNspDeployment(trench)
+	nspd, err := NewNspDeployment(e, trench)
 	if err != nil {
 		return nil, err
 	}
-	nsps, err := NewNspService(trench)
+	nsps, err := NewNspService(e, trench)
 	if err != nil {
 		return nil, err
 	}
-	p, err := NewProxy(trench)
+	p, err := NewProxy(e, trench)
 	if err != nil {
 		return nil, err
 	}
+	cfg := NewConfigMap(e, trench)
 	return &Meridio{
 		ipamDeployment: ipam,
 		ipamService:    ipamsvc,
@@ -65,10 +66,11 @@ func NewMeridio(trench *meridiov1alpha1.Trench) (*Meridio, error) {
 		nspDeployment:  nspd,
 		nspService:     nsps,
 		proxy:          p,
+		configmap:      cfg,
 	}, nil
 }
 
-func (m Meridio) ReconcileAll(e *common.Executor, cr *meridiov1alpha1.Trench) error {
+func (m Meridio) ReconcileAll() ([]common.Action, error) {
 	var actions []common.Action
 	resources := []Resources{
 		m.ipamService,
@@ -79,21 +81,17 @@ func (m Meridio) ReconcileAll(e *common.Executor, cr *meridiov1alpha1.Trench) er
 		m.nspService,
 		m.proxy,
 		m.ipamDeployment,
+		m.configmap,
 	}
 
 	for _, r := range resources {
-		action, err := r.getAction(e)
+		action, err := r.getAction()
 		if err != nil {
-			return fmt.Errorf("get %t action error: %s", r, err)
+			return nil, fmt.Errorf("get %t action error: %s", r, err)
 		}
 		if action != nil {
-			actions = append(actions, action)
+			actions = append(actions, action...)
 		}
 	}
-
-	err := e.RunAll(actions)
-	if err != nil {
-		return fmt.Errorf("running actions error: %s", err)
-	}
-	return nil
+	return actions, nil
 }

--- a/readme.md
+++ b/readme.md
@@ -134,11 +134,11 @@ attractor.meridio.nordix.org/attr1   100      eth0      ["gateway1","gateway2"] 
 
 ### Vip
 
-A vip is a resource that must be created with labels. It specifies its owner reference attractor and trench by `metadata.labels.attractor` and `metadata.labels.trench`.
+A vip is a resource that must be created with the label `metadata.labels.trench`, by which specifies its owner trench.
 
 To see how to configure and read the status of a vip, please refer to [vip spec](https://pkg.go.dev/github.com/nordix/meridio-operator/api/v1alpha1#VipSpec) and [vip status](https://pkg.go.dev/github.com/nordix/meridio-operator/api/v1alpha1#VipStatus).
 
-In the example below, two gateways will be created
+In the example below, two vips will be created.
 
 ```bash
 $ kubectl apply -f ./config/samples/meridio_v1alpha1_vip.yaml


### PR DESCRIPTION
Trench controller watches the children attractor and vips.
Once any of the resources is updated, trench controller will list all its
owning attractors and vips, looping all the attractors to look up its
expected vips, and then update the vip part in the configmap.

- Move the configmap reconciling of vips content to trench controller
- No need to add attractor label to the vip resources
- Remove the restriction in order that owner attractor must be created before vips
- Change the Attractor vips/gateways-in-use status according to the
configmap content. Previously during generating the configmap.
- Fix a bug in the gateway controller when the owner attractor cannot be
found. The operator pod would crash when setting the owner reference.
- Update readme.md regarding vip labels.