### PR TITLE
Add missing volumes in lb container in the LB pod

### DIFF
--- a/deployment/lb-fe.yaml
+++ b/deployment/lb-fe.yaml
@@ -78,6 +78,7 @@ spec:
               value:  # to be filed by operator
             - name: NSM_NSP_SERVICE
               value:  # Kubernetes default according to image tag
+          volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets
               readOnly: true


### PR DESCRIPTION
These volumes are required by the container to be able to use the Spire and NSM API.