### PR TITLE
Fix trench controller not include configmap in reconciliation loop

### DIFF
--- a/controllers/trench/configmap.go
+++ b/controllers/trench/configmap.go
@@ -186,12 +186,7 @@ func (c *ConfigMap) getAction() ([]common.Action, error) {
 		}
 		// create configmap if not exist, or update configmap
 		if cs == nil {
-			ds, err := c.getDesiredStatus(nil)
-			if err != nil {
-				return nil, err
-			}
-			c.exec.LogInfo(fmt.Sprintf("add action: create %s", elem))
-			actions = append(actions, common.NewCreateAction(ds, fmt.Sprintf("create %s", elem)))
+			c.exec.LogInfo(fmt.Sprintf("waiting %s to be created by attractor", elem))
 		} else {
 			ds, err := c.getReconciledDesiredStatus(vips4attr, cs)
 			if err != nil {
@@ -199,6 +194,7 @@ func (c *ConfigMap) getAction() ([]common.Action, error) {
 			}
 			if diff, diffmsg := diffConfigContent(cs.Data, ds.Data); diff {
 				c.exec.LogInfo(fmt.Sprintf("add action: update %s", elem))
+				c.exec.SetOwnerReference(ds, c.trench)
 				actions = append(actions, common.NewUpdateAction(ds, fmt.Sprintf("%s, %s", fmt.Sprintf("update %s", elem), diffmsg)))
 			}
 		}

--- a/controllers/trench/trench_controller.go
+++ b/controllers/trench/trench_controller.go
@@ -106,10 +106,14 @@ func (r *TrenchReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&source.Kind{Type: &meridiov1alpha1.Attractor{}},
 			&handler.EnqueueRequestForOwner{OwnerType: &meridiov1alpha1.Trench{}, IsController: false},
-		). // Attractors are not the controllers of Attractors, so here uses Watches with IsController: false
+		). // Trenches are not the controllers of Attractors, so here uses Watches with IsController: false
 		Watches(
 			&source.Kind{Type: &meridiov1alpha1.Vip{}},
 			&handler.EnqueueRequestForOwner{OwnerType: &meridiov1alpha1.Trench{}, IsController: false},
-		). // Attractors are not the controllers of Vips, so here uses Watches with IsController: false
+		). // Trenches are not the controllers of Vips, so here uses Watches with IsController: false
+		Watches(
+			&source.Kind{Type: &corev1.ConfigMap{}},
+			&handler.EnqueueRequestForOwner{OwnerType: &meridiov1alpha1.Trench{}, IsController: false},
+		). // Trenches are not the controllers of configmaps, so here uses Watches with IsController: false
 		Complete(r)
 }


### PR DESCRIPTION
- add watch of the configmap in trench controller
- set owner when updating configmap in trench controller
- remove the creation of configmap if not found by trench controller but
wait for it to be created by attractor instead
- add relevant e2e test: direct changes in configmap will be reverted by
the controllers