### PR TITLE
VLAN network service name fix

### DIFF
--- a/controllers/attractor/attractor_controller.go
+++ b/controllers/attractor/attractor_controller.go
@@ -79,7 +79,7 @@ func (r *AttractorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		nse, err := NewNSE(executor, attr)
+		nse, err := NewNSE(executor, attr, trench)
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/controllers/attractor/lb-fe.go
+++ b/controllers/attractor/lb-fe.go
@@ -85,7 +85,7 @@ func (l *LoadBalancer) getNscEnvVars(allEnv []corev1.EnvVar) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name:  nscEnvNwSvc,
-			Value: fmt.Sprintf("vlan://%s/ext-vlan?forwarder=forwarder-vlan", common.VlanNtwkSvcName(l.attractor)),
+			Value: fmt.Sprintf("vlan://%s/ext-vlan?forwarder=forwarder-vlan", common.VlanNtwkSvcName(l.trench)),
 		},
 	}
 

--- a/controllers/attractor/nse-vlan.go
+++ b/controllers/attractor/nse-vlan.go
@@ -25,12 +25,14 @@ type NseDeployment struct {
 	model     *appsv1.Deployment
 	attractor *meridiov1alpha1.Attractor
 	exec      *common.Executor
+	trench    *meridiov1alpha1.Trench
 }
 
-func NewNSE(e *common.Executor, attr *meridiov1alpha1.Attractor) (*NseDeployment, error) {
+func NewNSE(e *common.Executor, attr *meridiov1alpha1.Attractor, t *meridiov1alpha1.Trench) (*NseDeployment, error) {
 	nse := &NseDeployment{
 		attractor: attr,
 		exec:      e,
+		trench:    t,
 	}
 	err := nse.getModel()
 	if err != nil {
@@ -53,7 +55,7 @@ func (i *NseDeployment) getEnvVars(allEnv []corev1.EnvVar) []corev1.EnvVar {
 		},
 		{
 			Name:  nseEnvSerive,
-			Value: common.VlanNtwkSvcName(i.attractor),
+			Value: common.VlanNtwkSvcName(i.trench),
 		},
 		{
 			Name:  nseEnvPrefixV4,

--- a/controllers/common/const.go
+++ b/controllers/common/const.go
@@ -117,8 +117,8 @@ func LoadBalancerNsName(cr *meridiov1alpha1.Trench) string {
 	return strings.Join([]string{LBName, cr.ObjectMeta.Name, cr.ObjectMeta.Namespace}, ".")
 }
 
-func VlanNtwkSvcName(attr *meridiov1alpha1.Attractor) string {
-	return strings.Join([]string{NetworkServiceName, attr.ObjectMeta.Namespace}, ".")
+func VlanNtwkSvcName(cr *meridiov1alpha1.Trench) string {
+	return strings.Join([]string{NetworkServiceName, cr.ObjectMeta.Name, cr.ObjectMeta.Namespace}, ".")
 }
 
 func getResourceNamePrefix() string {


### PR DESCRIPTION
The trench name should be added to the NSM network service names.
Otherwise, NSCs from a trench might connect to NSEs in another trench
In this case, it was missing in the vlan NSM NS name.