### PR TITLE
Fix subnet validation

### DIFF
--- a/api/v1alpha1/attractor_webhook.go
+++ b/api/v1alpha1/attractor_webhook.go
@@ -19,7 +19,6 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
-	"net"
 	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -115,20 +114,14 @@ func (r *Attractor) validateAttractor() error {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata").Child("labels"), r.ObjectMeta.Labels, err.Error()))
 	}
 
-	_, n, err := net.ParseCIDR(r.Spec.VlanPrefixIPv4)
+	_, err := validatePrefix(r.Spec.VlanPrefixIPv4)
 	if err != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("vlan-ipv4-prefix"), r.Spec.VlanPrefixIPv4, err.Error()))
 	}
-	if n.String() != r.Spec.VlanPrefixIPv4 {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("vlan-ipv4-prefix"), r.Spec.VlanPrefixIPv4, fmt.Sprintf("not a valid prefix, probably %v should be used", n)))
-	}
 
-	_, n, err = net.ParseCIDR(r.Spec.VlanPrefixIPv6)
+	_, err = validatePrefix(r.Spec.VlanPrefixIPv6)
 	if err != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("vlan-ipv6-prefix"), r.Spec.VlanPrefixIPv6, err.Error()))
-	}
-	if n.String() != r.Spec.VlanPrefixIPv6 {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("vlan-ipv6-prefix"), r.Spec.VlanPrefixIPv6, fmt.Sprintf("not a valid prefix, probably %v should be used", n)))
 	}
 
 	if len(allErrs) == 0 {

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -104,11 +104,11 @@ func (t NetworkServiceType) IsValid() bool {
 }
 
 func validatePrefix(p string) (*net.IPNet, error) {
-	_, n, err := net.ParseCIDR(p)
+	ip, n, err := net.ParseCIDR(p)
 	if err != nil {
 		return nil, err
 	}
-	if n.String() != p {
+	if !ip.Equal(n.IP) {
 		return nil, fmt.Errorf("%s is not a valid prefix, probably %v should be used", p, n)
 	}
 	return n, nil


### PR DESCRIPTION
ParseCIDR will return the short format of the subnet, so if the user set a subnet to 0:0:0:0:0:0:0:0/0 (valid subnet), he will get the error "::/0 should be used". To fix it, the comparaison of the ip and subnet ip returned by ParsedCIDR is used.
In the Gateway webhook, the validatePrefix function is now used.