### PR TITLE
IPAM/NSP as Statefulset with PVC

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -32,6 +32,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - ""
   resources:
   - configmaps

--- a/controllers/common/const.go
+++ b/controllers/common/const.go
@@ -68,7 +68,7 @@ func ProxyDeploymentName(trench *meridiov1alpha1.Trench) string {
 	return getTrenchSuffixedName(ProxyName, trench)
 }
 
-func IPAMDeploymentName(trench *meridiov1alpha1.Trench) string {
+func IPAMStatefulSetName(trench *meridiov1alpha1.Trench) string {
 	return getTrenchSuffixedName(IpamName, trench)
 }
 
@@ -76,7 +76,7 @@ func NSEDeploymentName(attractor *meridiov1alpha1.Attractor) string {
 	return getAttractorSuffixedName(NseName, attractor)
 }
 
-func NSPDeploymentName(trench *meridiov1alpha1.Trench) string {
+func NSPStatefulSetName(trench *meridiov1alpha1.Trench) string {
 	return getTrenchSuffixedName(NspName, trench)
 }
 

--- a/controllers/common/models.go
+++ b/controllers/common/models.go
@@ -107,6 +107,19 @@ func GetDeploymentModel(f string) (*appsv1.Deployment, error) {
 	return deployment, nil
 }
 
+func GetStatefulSetModel(f string) (*appsv1.StatefulSet, error) {
+	data, err := os.Open(f)
+	if err != nil {
+		return nil, fmt.Errorf("open %s error: %s", f, err)
+	}
+	deployment := &appsv1.StatefulSet{}
+	err = yaml.NewYAMLOrJSONDecoder(data, 4096).Decode(deployment)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s error: %s", f, err)
+	}
+	return deployment, nil
+}
+
 func GetDaemonsetModel(f string) (*appsv1.DaemonSet, error) {
 	data, err := os.Open(f)
 	if err != nil {

--- a/controllers/trench/ipam-service.go
+++ b/controllers/trench/ipam-service.go
@@ -40,7 +40,7 @@ func (i *IpamService) insertParameters(svc *corev1.Service) *corev1.Service {
 	// else use the default parameters
 	ret := svc.DeepCopy()
 	ret.ObjectMeta.Name = common.IPAMServiceName(i.trench)
-	ret.Spec.Selector["app"] = common.IPAMDeploymentName(i.trench)
+	ret.Spec.Selector["app"] = common.IPAMStatefulSetName(i.trench)
 	ret.ObjectMeta.Namespace = i.trench.ObjectMeta.Namespace
 	return ret
 }

--- a/controllers/trench/nsp-service.go
+++ b/controllers/trench/nsp-service.go
@@ -53,7 +53,7 @@ func (i *NspService) insertParameters(svc *corev1.Service) *corev1.Service {
 	// else use the default parameters
 	ret := svc.DeepCopy()
 	ret.ObjectMeta.Name = common.NSPServiceName(i.trench)
-	ret.Spec.Selector["app"] = common.NSPDeploymentName(i.trench)
+	ret.Spec.Selector["app"] = common.NSPStatefulSetName(i.trench)
 	ret.ObjectMeta.Namespace = i.trench.ObjectMeta.Namespace
 	ret.Spec.Ports = i.getPorts()
 	return ret

--- a/controllers/trench/resources.go
+++ b/controllers/trench/resources.go
@@ -12,14 +12,14 @@ type Resources interface {
 }
 
 type Meridio struct {
-	ipamDeployment *IpamDeployment
-	ipamService    *IpamService
-	serviceAccount *ServiceAccount
-	role           *Role
-	roleBinding    *RoleBinding
-	nspDeployment  *NspDeployment
-	nspService     *NspService
-	configmap      *ConfigMap
+	ipamStatefulSet *IpamStatefulSet
+	ipamService     *IpamService
+	serviceAccount  *ServiceAccount
+	role            *Role
+	roleBinding     *RoleBinding
+	nspStatefulSet  *NspStatefulSet
+	nspService      *NspService
+	configmap       *ConfigMap
 }
 
 func NewMeridio(e *common.Executor, trench *meridiov1alpha1.Trench) (*Meridio, error) {
@@ -43,7 +43,7 @@ func NewMeridio(e *common.Executor, trench *meridiov1alpha1.Trench) (*Meridio, e
 	if err != nil {
 		return nil, err
 	}
-	nspd, err := NewNspDeployment(e, trench)
+	nspd, err := NewNspStatefulSet(e, trench)
 	if err != nil {
 		return nil, err
 	}
@@ -53,14 +53,14 @@ func NewMeridio(e *common.Executor, trench *meridiov1alpha1.Trench) (*Meridio, e
 	}
 	cfg := NewConfigMap(e, trench)
 	return &Meridio{
-		ipamDeployment: ipam,
-		ipamService:    ipamsvc,
-		serviceAccount: sa,
-		role:           role,
-		roleBinding:    rb,
-		nspDeployment:  nspd,
-		nspService:     nsps,
-		configmap:      cfg,
+		ipamStatefulSet: ipam,
+		ipamService:     ipamsvc,
+		serviceAccount:  sa,
+		role:            role,
+		roleBinding:     rb,
+		nspStatefulSet:  nspd,
+		nspService:      nsps,
+		configmap:       cfg,
 	}, nil
 }
 
@@ -69,9 +69,9 @@ func (m Meridio) ReconcileAll() error {
 		m.serviceAccount,
 		m.role,
 		m.roleBinding,
-		m.nspDeployment,
+		m.nspStatefulSet,
 		m.nspService,
-		m.ipamDeployment,
+		m.ipamStatefulSet,
 		m.ipamService,
 		m.configmap,
 	}

--- a/controllers/trench/trench_controller.go
+++ b/controllers/trench/trench_controller.go
@@ -47,6 +47,7 @@ type TrenchReconciler struct {
 //+kubebuilder:rbac:groups=meridio.nordix.org,namespace=system,resources=trenches/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=meridio.nordix.org,namespace=system,resources=trenches/finalizers,verbs=update
 //+kubebuilder:rbac:groups=apps,resources=deployments,namespace=system,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=apps,resources=statefulsets,namespace=system,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=daemonsets,namespace=system,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=services,namespace=system,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,namespace=system,verbs=get;list;watch;create;update;patch;delete

--- a/deployment/ipam.yaml
+++ b/deployment/ipam.yaml
@@ -1,11 +1,12 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: ipam
   labels:
     app: ipam
 spec:
   replicas: 1
+  serviceName: ipam
   selector:
     matchLabels:
       app: ipam
@@ -49,12 +50,26 @@ spec:
               value: unix:///run/spire/sockets/agent.sock
             - name: IPAM_PORT
               value: "7777"
+            - name: IPAM_DATASOURCE
+              value: /run/ipam/data/registry.db
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets
               readOnly: true
+            - name: ipam-data
+              mountPath: /run/ipam/data
+              readOnly: false
       volumes:
         - name: spire-agent-socket
           hostPath:
             path: /run/spire/sockets
             type: Directory
+  volumeClaimTemplates:
+    - metadata:
+        name: ipam-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi

--- a/deployment/nsp.yaml
+++ b/deployment/nsp.yaml
@@ -1,12 +1,13 @@
 # Source: meridio/templates/nsp.yaml
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: nsp
   labels:
     app: nsp
 spec:
   replicas: 1
+  serviceName: nsp
   selector:
     matchLabels:
       app: nsp
@@ -53,12 +54,26 @@ spec:
                   fieldPath: metadata.namespace
             - name: NSP_CONFIG_MAP_NAME
               value: # to be filled by operator
+            - name: NSP_DATASOURCE
+              value: /run/nsp/data/registry.db
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets
               readOnly: true
+            - name: nsp-data
+              mountPath: /run/nsp/data
+              readOnly: false
       volumes:
         - name: spire-agent-socket
           hostPath:
             path: /run/spire/sockets
             type: Directory
+  volumeClaimTemplates:
+    - metadata:
+        name: nsp-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi


### PR DESCRIPTION
The IPAM and NSP are now staefulset with a PVC attached and mount on the
containers to support data persistence as decribe in Nordix/Meridio#64. The
changes is Meridio are in PR Nordix/Meridio#127