### PR TITLE
Reduce redundant update when upgrade

### DIFF
--- a/controllers/attractor/nse-vlan.go
+++ b/controllers/attractor/nse-vlan.go
@@ -163,7 +163,7 @@ func (i *NseDeployment) getAction() error {
 		i.exec.AddCreateAction(ds)
 	} else {
 		ds := i.getReconciledDesiredStatus(cs)
-		if !equality.Semantic.DeepEqual(ds, cs) {
+		if !equality.Semantic.DeepEqual(ds.Spec, cs.Spec) {
 			i.exec.AddUpdateAction(ds)
 		}
 	}

--- a/controllers/conduit/lb-fe.go
+++ b/controllers/conduit/lb-fe.go
@@ -241,7 +241,7 @@ func (l *LoadBalancer) getAction() error {
 		l.exec.AddCreateAction(ds)
 	} else {
 		ds := l.getReconciledDesiredStatus(cs)
-		if !equality.Semantic.DeepEqual(ds, cs) {
+		if !equality.Semantic.DeepEqual(ds.Spec, cs.Spec) {
 			l.exec.AddUpdateAction(ds)
 		}
 	}

--- a/controllers/conduit/proxy.go
+++ b/controllers/conduit/proxy.go
@@ -179,7 +179,7 @@ func (i *Proxy) getAction() error {
 		i.exec.AddCreateAction(ds)
 	} else {
 		ds := i.getReconciledDesiredStatus(cs)
-		if !equality.Semantic.DeepEqual(ds, cs) {
+		if !equality.Semantic.DeepEqual(ds.Spec, cs.Spec) {
 			i.exec.AddUpdateAction(ds)
 		}
 	}

--- a/controllers/trench/ipam.go
+++ b/controllers/trench/ipam.go
@@ -128,7 +128,7 @@ func (i *IpamStatefulSet) getAction() error {
 		i.exec.AddCreateAction(ds)
 	} else {
 		ds := i.getReconciledDesiredStatus(cs)
-		if !equality.Semantic.DeepEqual(ds, cs) {
+		if !equality.Semantic.DeepEqual(ds.Spec, cs.Spec) {
 			i.exec.AddUpdateAction(ds)
 		}
 	}

--- a/controllers/trench/nsp.go
+++ b/controllers/trench/nsp.go
@@ -146,7 +146,7 @@ func (i *NspStatefulSet) getAction() error {
 		i.exec.AddCreateAction(ds)
 	} else {
 		ds := i.getReconciledDesiredStatus(cs)
-		if !equality.Semantic.DeepEqual(ds, cs) {
+		if !equality.Semantic.DeepEqual(ds.Spec, cs.Spec) {
 			i.exec.AddUpdateAction(ds)
 		}
 	}


### PR DESCRIPTION
Reduce redundant actions by comparing the spec part of deployments/statefuleset/daemonset to add update action.
The status of the above kinds keeps changing until they are fully ready, but status should not and cannot be changed by "update".