### PR TITLE
support for CRD resource requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.9.3)
 
 GINKGO = $(shell pwd)/bin/ginkgo
 ginkgo: ## Download ginkgo locally if necessary.

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 patchesStrategicMerge:
 # - patches/manager_webhook_patch_certmanager.yaml # [CERTMANAGER] To enable cert-manager, you need to uncomment all the sections with [CERTMANAGER]
 - patches/manager_webhook_patch_spire.yaml # [SPIRE] To enable spire, you need to uncomment all the sections with [SPIRE]
+- patches/manager_resource_templates_patch.yaml
 
 generatorOptions:
   disableNameSuffixHash: true
@@ -12,6 +13,17 @@ configMapGenerator:
 - files:
   - controller_manager_config.yaml
   name: manager-config
+- files:
+  - resource_requirements/load-balancer
+  - resource_requirements/nsc
+  - resource_requirements/fe
+  - resource_requirements/nse
+  - resource_requirements/proxy
+  - resource_requirements/nsp
+  - resource_requirements/ipam
+  name: resource-templates
+  options:
+    disableNameSuffixHash: true
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:

--- a/config/manager/patches/manager_resource_templates_patch.yaml
+++ b/config/manager/patches/manager_resource_templates_patch.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        volumeMounts:
+        - name: resource-templates
+          mountPath: "/template/resource"
+          readOnly: true
+      volumes:
+      - name: resource-templates
+        configMap:
+          name: resource-templates
+

--- a/config/manager/resource_requirements/fe
+++ b/config/manager/resource_requirements/fe
@@ -1,0 +1,26 @@
+# Disclaimer: below templates are merely examples, and are not proven to fit any production use case
+templates:
+- name: small
+  resources:
+    limits:
+      cpu: 200m
+      memory: 40Mi
+    requests:
+      cpu: 150m
+      memory: 20Mi
+- name: medium
+  resources:
+    limits:
+      cpu: 400m
+      memory: 120Mi
+    requests:
+      cpu: 300m
+      memory: 60Mi
+- name: large
+  resources:
+    limits:
+      cpu: "2"
+      memory: 250Mi
+    requests:
+      cpu: 500m
+      memory: 80Mi

--- a/config/manager/resource_requirements/ipam
+++ b/config/manager/resource_requirements/ipam
@@ -1,0 +1,26 @@
+# Disclaimer: below templates are merely examples, and are not proven to fit any production use case
+templates:
+- name: small
+  resources:
+    limits:
+      cpu: 200m
+      memory: 40Mi
+    requests:
+      cpu: 100m
+      memory: 20Mi
+- name: medium
+  resources:
+    limits:
+      cpu: 250m
+      memory: 80Mi
+    requests:
+      cpu: 150m
+      memory: 40Mi
+- name: large
+  resources:
+    limits:
+      cpu: 500m
+      memory: 200Mi
+    requests:
+      cpu: 200m
+      memory: 60Mi

--- a/config/manager/resource_requirements/load-balancer
+++ b/config/manager/resource_requirements/load-balancer
@@ -1,0 +1,26 @@
+# Disclaimer: below templates are merely examples, and are not proven to fit any production use case
+templates:
+- name: small
+  resources:
+    limits:
+      cpu: 200m
+      memory: 40Mi
+    requests:
+      cpu: 150m
+      memory: 20Mi
+- name: medium
+  resources:
+    limits:
+      cpu: 400m
+      memory: 120Mi
+    requests:
+      cpu: 300m
+      memory: 60Mi
+- name: large
+  resources:
+    limits:
+      cpu: "4"
+      memory: 300Mi
+    requests:
+      cpu: "1"
+      memory: 100Mi

--- a/config/manager/resource_requirements/nsc
+++ b/config/manager/resource_requirements/nsc
@@ -1,0 +1,26 @@
+# Disclaimer: below templates are merely examples, and are not proven to fit any production use case
+templates:
+- name: small
+  resources:
+    limits:
+      cpu: 150m
+      memory: 40Mi
+    requests:
+      cpu: 100m
+      memory: 20Mi
+- name: medium
+  resources:
+    limits:
+      cpu: 250m
+      memory: 80Mi
+    requests:
+      cpu: 200m
+      memory: 40Mi
+- name: large
+  resources:
+    limits:
+      cpu: 300m
+      memory: 120Mi
+    requests:
+      cpu: 200m
+      memory: 80Mi

--- a/config/manager/resource_requirements/nse
+++ b/config/manager/resource_requirements/nse
@@ -1,0 +1,26 @@
+# Disclaimer: below templates are merely examples, and are not proven to fit any production use case
+templates:
+- name: small
+  resources:
+    limits:
+      cpu: 150m
+      memory: 40Mi
+    requests:
+      cpu: 100m
+      memory: 20Mi
+- name: medium
+  resources:
+    limits:
+      cpu: 200m
+      memory: 120Mi
+    requests:
+      cpu: 150m
+      memory: 40Mi
+- name: large
+  resources:
+    limits:
+      cpu: 300m
+      memory: 200Mi
+    requests:
+      cpu: 200m
+      memory: 80Mi

--- a/config/manager/resource_requirements/nsp
+++ b/config/manager/resource_requirements/nsp
@@ -1,0 +1,26 @@
+# Disclaimer: below templates are merely examples, and are not proven to fit any production use case
+templates:
+- name: small
+  resources:
+    limits:
+      cpu: 200m
+      memory: 40Mi
+    requests:
+      cpu: 100m
+      memory: 20Mi
+- name: medium
+  resources:
+    limits:
+      cpu: 250m
+      memory: 120Mi
+    requests:
+      cpu: 150m
+      memory: 40Mi
+- name: large
+  resources:
+    limits:
+      cpu: 500m
+      memory: 250Mi
+    requests:
+      cpu: 200m
+      memory: 80Mi

--- a/config/manager/resource_requirements/proxy
+++ b/config/manager/resource_requirements/proxy
@@ -1,0 +1,26 @@
+# Disclaimer: below templates are merely examples, and are not proven to fit any production use case
+templates:
+- name: small
+  resources:
+    limits:
+      cpu: 150m
+      memory: 40Mi
+    requests:
+      cpu: 100m
+      memory: 20Mi
+- name: medium
+  resources:
+    limits:
+      cpu: 400m
+      memory: 120Mi
+    requests:
+      cpu: 200m
+      memory: 40Mi
+- name: large
+  resources:
+    limits:
+      cpu: "2"
+      memory: 200Mi
+    requests:
+      cpu: 500m
+      memory: 80Mi

--- a/controllers/attractor/nse-vlan.go
+++ b/controllers/attractor/nse-vlan.go
@@ -91,6 +91,12 @@ func (i *NseDeployment) insertParameters(dep *appsv1.Deployment) *appsv1.Deploym
 
 	ret.Spec.Template.Spec.ImagePullSecrets = common.GetImagePullSecrets()
 
+	// check resource requirement annotation update, and save annotation into deployment for visibility
+	oa, _ := common.GetResourceRequirementAnnotation(&dep.ObjectMeta)
+	if na, _ := common.GetResourceRequirementAnnotation(&i.attractor.ObjectMeta); na != oa {
+		common.SetResourceRequirementAnnotation(&i.attractor.ObjectMeta, &ret.ObjectMeta)
+	}
+
 	for x, container := range ret.Spec.Template.Spec.Containers {
 		switch name := container.Name; name {
 		case "nse":
@@ -114,6 +120,11 @@ func (i *NseDeployment) insertParameters(dep *appsv1.Deployment) *appsv1.Deploym
 				container.Ports = append([]corev1.ContainerPort{}, corev1.ContainerPort{HostPort: common.VlanNsePort, ContainerPort: common.VlanNsePort})
 			}
 			container.Env = i.getEnvVars(container.Env)
+			// set resource requirements for container (if not found, then values from model
+			// are kept even upon updates, as getReconciledDesiredStatus() overwrites containers)
+			if err := common.SetContainerResourceRequirements(&i.attractor.ObjectMeta, &container); err != nil {
+				i.exec.LogInfo(fmt.Sprintf("attractor %s, %v", i.attractor.ObjectMeta.Name, err))
+			}
 		default:
 			i.exec.LogError(fmt.Errorf("container %s not expected", name), "get container error")
 		}

--- a/controllers/common/const.go
+++ b/controllers/common/const.go
@@ -49,6 +49,9 @@ const (
 	CMName      = "meridio-configuration"
 
 	NetworkServiceName = "external-vlan"
+
+	ResourceRequirementKey          = "resource-template"
+	ResourceRequirementTemplatePath = "template/resource"
 )
 
 func ServiceAccountName(trench *meridiov1alpha1.Trench) string {

--- a/controllers/common/resource.go
+++ b/controllers/common/resource.go
@@ -1,0 +1,126 @@
+package common
+
+import (
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+/* Example data layout of a resource template file:
+
+templates:
+- name: small
+  resources:
+    limits:
+      cpu: 100m
+      memory: 32Mi
+    requests:
+      cpu: 30m
+      memory: 16Mi
+- name: medium
+  resources:
+    limits:
+      cpu: 200m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 32Mi
+- name: large
+  resources:
+    limits:
+      cpu: "1"
+      memory: 256Mi
+    requests:
+      cpu: 200m
+      memory: 64Mi
+- name: xlarge
+  resources:
+    limits:
+      cpu: "4"
+      memory: 512Mi
+    requests:
+      cpu: "2"
+      memory: 128Mi
+*/
+
+type NamedResourceRequirements struct {
+	Name      string                      `json:"name" protobuf:"bytes,1,opt,name=name"`
+	Resources corev1.ResourceRequirements `json:"resources,omitempty" protobuf:"bytes,2,opt,name=resources"`
+}
+
+// ResourceRequirementTemplates -
+// Describes the data layout of a resource requirement template file
+type ResourceRequirementTemplates struct {
+	Templates []NamedResourceRequirements `json:"templates,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,1,rep,name=templates"`
+}
+
+// getResourceRequirementTemplates -
+// Reads resource requirement templates from file
+func getResourceRequirementTemplates(f string) (*ResourceRequirementTemplates, error) {
+	data, err := os.Open(f)
+	if err != nil {
+		return nil, fmt.Errorf("open %s error: %s", f, err)
+	}
+	t := &ResourceRequirementTemplates{}
+	err = yaml.NewYAMLOrJSONDecoder(data, 4096).Decode(t)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s error: %s", f, err)
+	}
+	return t, nil
+}
+
+// GetResourceRequirementAnnotation -
+// Gets ResourceRequirementKey annotation based on param 'from'
+func GetResourceRequirementAnnotation(from *metav1.ObjectMeta) (string, bool) {
+	val, ok := from.Annotations[ResourceRequirementKey]
+	return val, ok
+}
+
+// SetResourceRequirementAnnotation -
+// Sets ResourceRequirementKey annotation based on param 'from'.
+func SetResourceRequirementAnnotation(from *metav1.ObjectMeta, into *metav1.ObjectMeta) {
+	if val, ok := GetResourceRequirementAnnotation(from); ok && val != "" {
+		// annotatate param 'into' with ResourceRequirementKey
+		if into.Annotations == nil {
+			into.Annotations = make(map[string]string)
+		}
+		into.Annotations[ResourceRequirementKey] = val
+	} else {
+		// remove annotation from param 'into'
+		if _, ok := GetResourceRequirementAnnotation(into); ok {
+			delete(into.Annotations, ResourceRequirementKey)
+		}
+	}
+}
+
+// GetContainerResourceRequirements -
+// Reads and searches template resource requirements for container.
+// (A template resource requirement with param 'templateName' must exist for a match)
+func GetContainerResourceRequirements(containerName, templateName string) (*corev1.ResourceRequirements, error) {
+	rrt, err := getResourceRequirementTemplates(fmt.Sprintf("%s/%s", ResourceRequirementTemplatePath, containerName))
+	if err != nil {
+		return nil, err
+	}
+	for _, template := range rrt.Templates {
+		if template.Name == templateName {
+			return &template.Resources, nil
+		}
+	}
+	return nil, fmt.Errorf("container %s, not found resource requirement template: %s", containerName, templateName)
+}
+
+// SetContainerResourceRequirements -
+// Finds and sets resource requirements for container.
+func SetContainerResourceRequirements(from *metav1.ObjectMeta, container *corev1.Container) error {
+	if val, ok := GetResourceRequirementAnnotation(from); ok && val != "" {
+		rr, err := GetContainerResourceRequirements(container.Name, val)
+		if err != nil {
+			return err
+		}
+		container.Resources = *rr
+	}
+	return nil
+}

--- a/deployment/ipam.yaml
+++ b/deployment/ipam.yaml
@@ -29,8 +29,8 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=
-                - -connect-timeout=100ms
-                - -rpc-timeout=150ms
+                - -connect-timeout=250ms
+                - -rpc-timeout=350ms
             initialDelaySeconds: 0
             periodSeconds: 2
             timeoutSeconds: 2
@@ -43,8 +43,8 @@ spec:
                 - -spiffe
                 - -addr=:7777
                 - -service=
-                - -connect-timeout=100ms
-                - -rpc-timeout=150ms
+                - -connect-timeout=250ms
+                - -rpc-timeout=350ms
             failureThreshold: 5
             initialDelaySeconds: 0
             periodSeconds: 10
@@ -56,8 +56,8 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=
-                - -connect-timeout=100ms
-                - -rpc-timeout=150ms
+                - -connect-timeout=250ms
+                - -rpc-timeout=350ms
             failureThreshold: 5
             initialDelaySeconds: 0
             periodSeconds: 10

--- a/deployment/lb-fe.yaml
+++ b/deployment/lb-fe.yaml
@@ -54,8 +54,8 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=
-                - -connect-timeout=100ms
-                - -rpc-timeout=150ms
+                - -connect-timeout=250ms
+                - -rpc-timeout=350ms
             initialDelaySeconds: 0
             periodSeconds: 2
             timeoutSeconds: 2
@@ -67,8 +67,8 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=Readiness
-                - -connect-timeout=100ms
-                - -rpc-timeout=150ms
+                - -connect-timeout=250ms
+                - -rpc-timeout=350ms
             failureThreshold: 5
             initialDelaySeconds: 0
             periodSeconds: 10
@@ -80,8 +80,8 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=
-                - -connect-timeout=100ms
-                - -rpc-timeout=150ms
+                - -connect-timeout=250ms
+                - -rpc-timeout=350ms
             failureThreshold: 5
             initialDelaySeconds: 0
             periodSeconds: 10
@@ -156,8 +156,8 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=
-                - -connect-timeout=100ms
-                - -rpc-timeout=150ms
+                - -connect-timeout=250ms
+                - -rpc-timeout=350ms
             initialDelaySeconds: 0
             periodSeconds: 2
             timeoutSeconds: 2
@@ -169,8 +169,8 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=Readiness
-                - -connect-timeout=100ms
-                - -rpc-timeout=150ms
+                - -connect-timeout=250ms
+                - -rpc-timeout=350ms
             initialDelaySeconds: 0
             periodSeconds: 10
             timeoutSeconds: 3
@@ -182,8 +182,8 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=
-                - -connect-timeout=100ms
-                - -rpc-timeout=150ms
+                - -connect-timeout=250ms
+                - -rpc-timeout=350ms
             initialDelaySeconds: 0
             periodSeconds: 10
             timeoutSeconds: 3

--- a/deployment/nse-vlan.yaml
+++ b/deployment/nse-vlan.yaml
@@ -35,8 +35,8 @@ spec:
                 - -spiffe
                 - -addr=:5003
                 - -service=
-                - -connect-timeout=100ms
-                - -rpc-timeout=150ms
+                - -connect-timeout=250ms
+                - -rpc-timeout=350ms
             initialDelaySeconds: 0
             periodSeconds: 2
             timeoutSeconds: 2
@@ -49,8 +49,8 @@ spec:
                 - -spiffe
                 - -addr=:5003
                 - -service=
-                - -connect-timeout=100ms
-                - -rpc-timeout=150ms
+                - -connect-timeout=250ms
+                - -rpc-timeout=350ms
             initialDelaySeconds: 0
             periodSeconds: 10
             timeoutSeconds: 3
@@ -63,8 +63,8 @@ spec:
                 - -spiffe
                 - -addr=:5003
                 - -service=
-                - -connect-timeout=100ms
-                - -rpc-timeout=150ms
+                - -connect-timeout=250ms
+                - -rpc-timeout=350ms
             initialDelaySeconds: 0
             periodSeconds: 10
             timeoutSeconds: 3

--- a/deployment/nsp.yaml
+++ b/deployment/nsp.yaml
@@ -31,8 +31,8 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=
-                - -connect-timeout=100ms
-                - -rpc-timeout=150ms
+                - -connect-timeout=250ms
+                - -rpc-timeout=350ms
             initialDelaySeconds: 0
             periodSeconds: 2
             timeoutSeconds: 2
@@ -45,8 +45,8 @@ spec:
                 - -spiffe
                 - -addr=:7778
                 - -service=
-                - -connect-timeout=100ms
-                - -rpc-timeout=150ms
+                - -connect-timeout=250ms
+                - -rpc-timeout=350ms
             failureThreshold: 5
             initialDelaySeconds: 0
             periodSeconds: 10
@@ -58,8 +58,8 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=
-                - -connect-timeout=100ms
-                - -rpc-timeout=150ms
+                - -connect-timeout=250ms
+                - -rpc-timeout=350ms
             failureThreshold: 5
             initialDelaySeconds: 0
             periodSeconds: 10

--- a/deployment/proxy.yaml
+++ b/deployment/proxy.yaml
@@ -34,8 +34,8 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=
-                - -connect-timeout=100ms
-                - -rpc-timeout=150ms
+                - -connect-timeout=250ms
+                - -rpc-timeout=350ms
             initialDelaySeconds: 0
             periodSeconds: 2
             timeoutSeconds: 2
@@ -47,8 +47,8 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=Readiness
-                - -connect-timeout=100ms
-                - -rpc-timeout=150ms
+                - -connect-timeout=250ms
+                - -rpc-timeout=350ms
             failureThreshold: 5
             initialDelaySeconds: 0
             periodSeconds: 10
@@ -60,8 +60,8 @@ spec:
                 - /bin/grpc_health_probe
                 - -addr=unix:///tmp/health.sock
                 - -service=
-                - -connect-timeout=100ms
-                - -rpc-timeout=150ms
+                - -connect-timeout=250ms
+                - -rpc-timeout=350ms
             failureThreshold: 5
             initialDelaySeconds: 0
             periodSeconds: 10


### PR DESCRIPTION
- Resource Requirements can be set for Trench, Attractor and Conduit through annotation. (key=resource-template)
- For each container making up a specific CRD the annotation value is interpreted as the name of a Resource Requirements template. (So templates are defined per container.)
- CRD annotation update is supported and will be applied according to the related deployment/daemonset/statefulset 'Update Strategy'.
- The Resource Requirement templates are stored in a Config Map, and its content is mounted as a volume in the Operator POD.
- The Config Map can be updated on the fly if needed. But changes do not take effect on existing CRDs, unless the associated Reconcile() function is invoked by kubernetes for some reason.
 - A template basically wraps a k8s corev1 API ResourceRequirements.
 - Currently there are 3 predefined Resource Requirements templates per container with names: "small", "medium", "large".
 
 Example;
    
      cat <<EOF | kubectl apply -f -
      apiVersion: meridio.nordix.org/v1alpha1
      kind: Trench
      metadata:
        name: trench-a
        annotations:
          resource-template: "small"
      spec:
        ip-family: dualstack
      EOF

