### PR TITLE
NSM Registry as environment variable

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -52,6 +52,8 @@ spec:
         env:
           - name: RESOURCE_NAME_PREFIX
             value: ""
+          - name: NSM_REGISTRY_SERVICE
+            value: "nsm-registry-svc.nsm:5002"
           - name: IMAGE_PULL_SECRET
             value: "" # multiple secrets supported, use "," as the delimiter
           - name: WATCH_NAMESPACE

--- a/controllers/attractor/nse-vlan.go
+++ b/controllers/attractor/nse-vlan.go
@@ -52,6 +52,10 @@ func (i *NseDeployment) getEnvVars(allEnv []corev1.EnvVar) []corev1.EnvVar {
 				i.attractor.Spec.Interface.NSMVlan.BaseInterface),
 		},
 		{
+			Name:  "NSM_CONNECT_TO",
+			Value: common.GetNSMRegistryService(),
+		},
+		{
 			Name:  nseEnvPrefixV4,
 			Value: i.attractor.Spec.Interface.PrefixIPv4,
 		},
@@ -65,7 +69,6 @@ func (i *NseDeployment) getEnvVars(allEnv []corev1.EnvVar) []corev1.EnvVar {
 		// append all hard coded envVars
 		if e.Name == "SPIFFE_ENDPOINT_SOCKET" ||
 			e.Name == "NSM_NAME" ||
-			e.Name == "NSM_CONNECT_TO" ||
 			e.Name == "NSM_POINT2POINT" ||
 			e.Name == "NSM_REGISTER_SERVICE" ||
 			e.Name == "NSM_LISTEN_ON" ||

--- a/controllers/common/const.go
+++ b/controllers/common/const.go
@@ -15,6 +15,7 @@ const (
 	SAName                = "meridio-sa"
 	ResourceNamePrefixEnv = "RESOURCE_NAME_PREFIX"
 	ImagePullSecretEnv    = "IMAGE_PULL_SECRET"
+	NSMRegistryServiceEnv = "NSM_REGISTRY_SERVICE"
 
 	Registry        = "registry.nordix.org"
 	Organization    = "cloud-native/meridio"
@@ -125,6 +126,10 @@ func VlanNtwkSvcName(cr *meridiov1alpha1.Trench) string {
 
 func getResourceNamePrefix() string {
 	return os.Getenv(ResourceNamePrefixEnv)
+}
+
+func GetNSMRegistryService() string {
+	return os.Getenv(NSMRegistryServiceEnv)
 }
 
 func GetImagePullSecrets() []corev1.LocalObjectReference {


### PR DESCRIPTION
The NSM registry has been added to environment variable so it will be added to the NSE-VLAN. This allows NSM to run in other Kubernetes namespaces.