### PR TITLE
attractor; support FE upgrade in spite of no extra nodes

### DIFF
--- a/deployment/lb-fe.yaml
+++ b/deployment/lb-fe.yaml
@@ -15,7 +15,7 @@ spec:
   revisionHistoryLimit: 10
   strategy:
     rollingUpdate:
-      maxSurge: 25%
+      maxSurge: 0
       maxUnavailable: 25%
     type: RollingUpdate
   template:

--- a/deployment/nse-vlan.yaml
+++ b/deployment/nse-vlan.yaml
@@ -15,8 +15,8 @@ spec:
   revisionHistoryLimit: 10
   strategy:
     rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
+      maxSurge: 0
+      maxUnavailable: 100%
     type: RollingUpdate
   template:
     metadata:


### PR DESCRIPTION
-The Rolling Update parameter 'maxSurge' of the FE deployment's
has been set to zero. In order to insure upgrade won't get stuck
because of the POD antiaffinity rules applied (in case there are
no spare nodes that could be used to schedule additional FE PODs).

-Similarly, for the vlan-nse deployment 'maxSurge' has been set to zero,
while 'maxUnavailable' has been set to 100%, to avoid that two VLAN NSEs
could run at once (even temporarily) in a trench during upgrade. The goal
is to avoid assigning IPs to new FE PODs by old NSE during Attractor upgrade.
As such IPs wouldn't be cleared from the new FE PODs.
(This is merely a workaround until a persistent IPAM solution is implemented
for the VLAN NSE to maintain information on leased IPs.)

Note: IP collision across old and new FEs might occu during upgrade until an IPAM with persistent storage is introduced for the VLAN NSE.