### PR TITLE
manager; prevent multiple operators running at once during upgrade

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -17,6 +17,11 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 100%
+    type: RollingUpdate
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
In case leader election is disabled it makes sense to prevent
multiple operator instances running simultaneously during
upgrade (even temporarily).