### PR TITLE
Use different external interace name when VLAN ID=0

### DIFF
--- a/controllers/common/const.go
+++ b/controllers/common/const.go
@@ -157,5 +157,9 @@ func NsName(meta metav1.ObjectMeta) string {
 }
 
 func GetExternalInterfaceName(attractor *meridiov1alpha1.Attractor) string {
-	return fmt.Sprintf("ext-vlan.%d", *attractor.Spec.Interface.NSMVlan.VlanID)
+	name := "ext"
+	if *attractor.Spec.Interface.NSMVlan.VlanID != 0 {
+		name = fmt.Sprintf("ext-vlan.%d", *attractor.Spec.Interface.NSMVlan.VlanID)
+	}
+	return name
 }


### PR DESCRIPTION
In case VLAN ID=0 NSM won't create a VLAN subinterface.
In fact, the base interface might not even be a VLAN interface.
So let Remote VLAN NSE create an interace with the name "ext"
in such cases.

Testing VLAN ID=0 requires NSM 1.4 (including the fix to disable data path healing in the NSC)

Also, prior to starting vpp forwarders the device selector config map must be updated to contain the VLAN interface(s) to be used
by Attractor(s) as base-interface(s).

Example:
```
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: device-selector
data:
  selector: "---\ninterfaces:\n
    \  - name: eth0\n
    \    matches:\n
    \       - labelSelector:\n
    \          - via: eth0\n
    \  - name: eth1.200\n
    \    matches:\n
    \       - labelSelector:\n
    \          - via: eth1.200\n
    \  - name: eth1\n
    \    matches:\n
    \       - labelSelector:\n
    \          - via: eth1\n     \n"


apiVersion: meridio.nordix.org/v1alpha1
kind: Attractor
metadata:
  name: attr-a1
  labels:
    trench: trench-a
  annotations:
    resource-template: "medium"
spec:
  replicas: 2
  gateways:
    - gateway-a1
    - gateway-a2
    - gateway-a3
    - gateway-a4
  composites:
    - load-balancer
  vips:
    - vip-a1
    - vip-a2
    - vip-a3
  interface:
    name: eth1.100
    ipv4-prefix: 169.254.100.0/24
    ipv6-prefix: 100:100::/64
    type: nsm-vlan
    nsm-vlan:
      vlan-id: 0
      base-interface: eth1.200
```
