### PR TITLE
Enable readOnlyRootFilesystem=true

### DIFF
--- a/deployment/ipam.yaml
+++ b/deployment/ipam.yaml
@@ -101,6 +101,11 @@ spec:
             - name: ipam-data
               mountPath: /run/ipam/data
               readOnly: false
+            - name: tmp
+              mountPath: /tmp
+              readOnly: false
+          securityContext:
+            readOnlyRootFilesystem: true
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -111,6 +116,9 @@ spec:
           hostPath:
             path: /run/spire/sockets
             type: Directory
+        - name: tmp
+          emptyDir:
+            medium: Memory
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/deployment/lb-fe.yaml
+++ b/deployment/lb-fe.yaml
@@ -113,7 +113,11 @@ spec:
             - name: nsm-socket
               mountPath: /var/lib/networkservicemesh
               readOnly: false
+            - name: tmp-lb
+              mountPath: /tmp
+              readOnly: false
           securityContext:
+            readOnlyRootFilesystem: true
             capabilities:
               add: ["NET_ADMIN"]
           terminationMessagePath: /dev/termination-log
@@ -211,12 +215,25 @@ spec:
             - name: NFE_LOG_LEVEL
               value: "DEBUG"
           securityContext:
+            readOnlyRootFilesystem: true
             capabilities:
               add: ["NET_ADMIN"]
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets
               readOnly: true
+            - name: tmp-fe
+              mountPath: /tmp
+              readOnly: false
+            - name: run
+              mountPath: /var/run/bird
+              readOnly: false
+            - name: etc
+              mountPath: /etc/bird
+              readOnly: false
+            - name: log
+              mountPath: /var/log
+              readOnly: false
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
       volumes:
@@ -228,3 +245,18 @@ spec:
           hostPath:
             path: /var/lib/networkservicemesh
             type: DirectoryOrCreate
+        - name: tmp-lb
+          emptyDir:
+            medium: Memory
+        - name: tmp-fe
+          emptyDir:
+            medium: Memory
+        - name: run
+          emptyDir:
+            medium: Memory
+        - name: etc
+          emptyDir:
+            medium: Memory
+        - name: log
+          emptyDir:
+            medium: Memory

--- a/deployment/nse-vlan.yaml
+++ b/deployment/nse-vlan.yaml
@@ -105,6 +105,8 @@ spec:
             - name: nsm-socket
               mountPath: /var/lib/networkservicemesh
               readOnly: false
+          securityContext:
+            readOnlyRootFilesystem: true
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
       volumes:

--- a/deployment/nsp.yaml
+++ b/deployment/nsp.yaml
@@ -87,6 +87,11 @@ spec:
             - name: nsp-data
               mountPath: /run/nsp/data
               readOnly: false
+            - name: tmp
+              mountPath: /tmp
+              readOnly: false
+          securityContext:
+            readOnlyRootFilesystem: true
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -97,6 +102,9 @@ spec:
           hostPath:
             path: /run/spire/sockets
             type: Directory
+        - name: tmp
+          emptyDir:
+            medium: Memory
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/deployment/proxy.yaml
+++ b/deployment/proxy.yaml
@@ -111,7 +111,11 @@ spec:
             - name: nsm-socket
               mountPath: /var/lib/networkservicemesh
               readOnly: true
+            - name: tmp
+              mountPath: /tmp
+              readOnly: false
           securityContext:
+            readOnlyRootFilesystem: true
             capabilities:
               add: ["NET_ADMIN"]
       volumes:
@@ -123,3 +127,6 @@ spec:
           hostPath:
             path: /var/lib/networkservicemesh
             type: DirectoryOrCreate
+        - name: tmp
+          emptyDir:
+            medium: Memory


### PR DESCRIPTION
NSM NSC is not changed. (It uses dnscontext client, but currently
there's no way to change resolv.conf path in the NSC. However,
failure to writing resolv.conf won't result in a fatal error, so
readOnlyRootFilesystem=true could be set if really needed.)

Remote VLAN NSE works with readOnlyRootFilesystem=true without problems.
(No guarantees for future releases though.)

Note: Set 'medium' of emptyDir volumes to 'Memory'. Thus get mounted as tmpfs.
Meaning they contribute to the containers' memory consumption. (Must be
considered when setting memory resource requests/limits.)