### PR TITLE
Enable Multi-conduit and Multi-attractor

### DIFF
--- a/api/v1alpha1/attractor_webhook.go
+++ b/api/v1alpha1/attractor_webhook.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -61,24 +60,6 @@ func (r *Attractor) ValidateCreate() error {
 	err := attractorClient.Get(context.TODO(), selector, trench)
 	if err != nil || trench == nil {
 		return fmt.Errorf("unable to find the trench in label, %s cannot be created", r.GroupVersionKind().Kind)
-	}
-
-	// validation: get all attractors with same trench, verdict the number should not be greater than 1
-	al := &AttractorList{}
-	sel := labels.Set{"trench": trench.ObjectMeta.Name}
-	err = attractorClient.List(context.TODO(), al, &client.ListOptions{
-		LabelSelector: sel.AsSelector(),
-		Namespace:     r.ObjectMeta.Namespace,
-	})
-
-	if err != nil {
-		return fmt.Errorf("unable to get attractors")
-	} else if len(al.Items) >= 1 {
-		var names []string
-		for _, a := range al.Items {
-			names = append(names, a.ObjectMeta.Name)
-		}
-		return fmt.Errorf("only one attractor is allowed in a trench, but also found %s", strings.Join(names, ", "))
 	}
 
 	if r.Spec.Replicas == nil {

--- a/controllers/attractor/lb-fe.go
+++ b/controllers/attractor/lb-fe.go
@@ -90,7 +90,7 @@ func (l *LoadBalancer) getNscEnvVars(allEnv []corev1.EnvVar) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name:  "NSM_NETWORK_SERVICES",
-			Value: fmt.Sprintf("kernel://%s/%s", common.VlanNtwkSvcName(l.attractor), common.GetExternalInterfaceName(l.attractor)),
+			Value: fmt.Sprintf("kernel://%s/%s", common.VlanNtwkSvcName(l.attractor, l.trench), common.GetExternalInterfaceName(l.attractor)),
 		},
 		{
 			Name:  "NSM_LOG_LEVEL",

--- a/controllers/attractor/lb-fe.go
+++ b/controllers/attractor/lb-fe.go
@@ -90,7 +90,7 @@ func (l *LoadBalancer) getNscEnvVars(allEnv []corev1.EnvVar) []corev1.EnvVar {
 	env := []corev1.EnvVar{
 		{
 			Name:  "NSM_NETWORK_SERVICES",
-			Value: fmt.Sprintf("kernel://%s/%s", common.VlanNtwkSvcName(l.trench), common.GetExternalInterfaceName(l.attractor)),
+			Value: fmt.Sprintf("kernel://%s/%s", common.VlanNtwkSvcName(l.attractor), common.GetExternalInterfaceName(l.attractor)),
 		},
 		{
 			Name:  "NSM_LOG_LEVEL",

--- a/controllers/attractor/nse-vlan.go
+++ b/controllers/attractor/nse-vlan.go
@@ -46,7 +46,7 @@ func (i *NseDeployment) getEnvVars(allEnv []corev1.EnvVar) []corev1.EnvVar {
 		{
 			Name: nseEnvServices,
 			Value: fmt.Sprintf("%s { vlan: %d; via: %s }",
-				common.VlanNtwkSvcName(i.trench),
+				common.VlanNtwkSvcName(i.attractor),
 				*i.attractor.Spec.Interface.NSMVlan.VlanID,
 				i.attractor.Spec.Interface.NSMVlan.BaseInterface),
 		},

--- a/controllers/attractor/nse-vlan.go
+++ b/controllers/attractor/nse-vlan.go
@@ -46,7 +46,7 @@ func (i *NseDeployment) getEnvVars(allEnv []corev1.EnvVar) []corev1.EnvVar {
 		{
 			Name: nseEnvServices,
 			Value: fmt.Sprintf("%s { vlan: %d; via: %s }",
-				common.VlanNtwkSvcName(i.attractor),
+				common.VlanNtwkSvcName(i.attractor, i.trench),
 				*i.attractor.Spec.Interface.NSMVlan.VlanID,
 				i.attractor.Spec.Interface.NSMVlan.BaseInterface),
 		},

--- a/controllers/common/const.go
+++ b/controllers/common/const.go
@@ -72,8 +72,8 @@ func LbFeDeploymentName(attractor *meridiov1alpha1.Attractor) string {
 	return GetSuffixedName(LBName, attractor.ObjectMeta.Name)
 }
 
-func ProxyDeploymentName(trench *meridiov1alpha1.Trench) string {
-	return GetSuffixedName(ProxyName, trench.ObjectMeta.Name)
+func ProxyDeploymentName(conduit *meridiov1alpha1.Conduit) string {
+	return GetSuffixedName(ProxyName, conduit.ObjectMeta.Name)
 }
 
 func IPAMStatefulSetName(trench *meridiov1alpha1.Trench) string {
@@ -124,7 +124,7 @@ func LoadBalancerNsName(conduit, trench, namespace string) string {
 	return strings.Join([]string{conduit, trench, namespace}, ".")
 }
 
-func VlanNtwkSvcName(cr *meridiov1alpha1.Trench) string {
+func VlanNtwkSvcName(cr *meridiov1alpha1.Attractor) string {
 	return strings.Join([]string{NetworkServiceName, cr.ObjectMeta.Name, cr.ObjectMeta.Namespace}, ".")
 }
 

--- a/controllers/common/const.go
+++ b/controllers/common/const.go
@@ -124,8 +124,8 @@ func LoadBalancerNsName(conduit, trench, namespace string) string {
 	return strings.Join([]string{conduit, trench, namespace}, ".")
 }
 
-func VlanNtwkSvcName(cr *meridiov1alpha1.Attractor) string {
-	return strings.Join([]string{NetworkServiceName, cr.ObjectMeta.Name, cr.ObjectMeta.Namespace}, ".")
+func VlanNtwkSvcName(attractorCr *meridiov1alpha1.Attractor, trenchCr *meridiov1alpha1.Trench) string {
+	return strings.Join([]string{NetworkServiceName, attractorCr.ObjectMeta.Name, trenchCr.ObjectMeta.Name, trenchCr.ObjectMeta.Namespace}, ".")
 }
 
 func getResourceNamePrefix() string {

--- a/controllers/conduit/proxy.go
+++ b/controllers/conduit/proxy.go
@@ -103,7 +103,7 @@ func (i *Proxy) getEnvVars(allEnv []corev1.EnvVar) []corev1.EnvVar {
 func (i *Proxy) insertParameters(init *appsv1.DaemonSet) *appsv1.DaemonSet {
 	// if status proxy daemonset parameters are specified in the cr, use those
 	// else use the default parameters
-	proxyDeploymentName := common.ProxyDeploymentName(i.trench)
+	proxyDeploymentName := common.ProxyDeploymentName(i.conduit)
 	ds := init.DeepCopy()
 	ds.ObjectMeta.Name = proxyDeploymentName
 	ds.ObjectMeta.Namespace = i.trench.ObjectMeta.Namespace
@@ -173,7 +173,7 @@ func (i *Proxy) getModel() error {
 func (i *Proxy) getSelector() client.ObjectKey {
 	return client.ObjectKey{
 		Namespace: i.trench.ObjectMeta.Namespace,
-		Name:      common.ProxyDeploymentName(i.trench),
+		Name:      common.ProxyDeploymentName(i.conduit),
 	}
 }
 


### PR DESCRIPTION
## Description
- Lock for only 1 attractor and only 1 conduit removed from the webhook
- Proxy name modified to `proxy-<conduit-name>` instead of `proxy-<trench-name>`
- nse-vlan NS name renamed from `external-vlan.<trench-name>.<namespace>` to `external-vlan.<attractor-name>.<namespace>`
- Vip and composite validation in flow and attractor
  - A VIP cannot be shared between flows that are in different conduits
  - A VIP cannot be shared between 2 attractors
  - A Conduit cannot be shared between 2 attractors

## Issue link
https://github.com/Nordix/Meridio-Operator/issues/94
https://github.com/Nordix/Meridio/pull/239

## Checklist

- Purpose
    - [ ] Bug fix
    - [x] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No