### PR TITLE
runAsNonRoot: true

### DIFF
--- a/config/manager/deployment/ipam.yaml
+++ b/config/manager/deployment/ipam.yaml
@@ -105,11 +105,21 @@ spec:
               mountPath: /tmp
               readOnly: false
           securityContext:
+            runAsNonRoot: true
             readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+              - all
+              add:
+              - DAC_OVERRIDE  # required by debug tools netstat, ss
+              - NET_RAW  # required by debug tool ping
+              - SYS_PTRACE  # required by debug tools netstat, ss to list process names/ids
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
-      securityContext: {}
+      securityContext:
+        fsGroup: 2000
+        fsGroupChangePolicy: "OnRootMismatch"
       terminationGracePeriodSeconds: 30
       volumes:
         - name: spire-agent-socket

--- a/config/manager/deployment/lb-fe.yaml
+++ b/config/manager/deployment/lb-fe.yaml
@@ -117,9 +117,18 @@ spec:
               mountPath: /tmp
               readOnly: false
           securityContext:
+            runAsNonRoot: true
             readOnlyRootFilesystem: true
             capabilities:
-              add: ["NET_ADMIN"]
+              drop:
+              - all
+              add:
+              - NET_ADMIN  # required by load-balancer and nfqlb
+              - DAC_OVERRIDE  # required by load-balancer to use nsm-socket and by debug tools netstat, ss
+              - IPC_LOCK  # required by nfqlb because of shared-mem
+              - IPC_OWNER  # required by nfqlb because of shared-mem
+              - NET_RAW  # required by debug tools tcpdump, ping
+              - SYS_PTRACE  # required by debug tools netstat, ss to list process names/ids
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
         - name: nsc
@@ -217,9 +226,17 @@ spec:
             - name: NFE_LOG_LEVEL
               value: "DEBUG"
           securityContext:
+            runAsNonRoot: true
             readOnlyRootFilesystem: true
             capabilities:
-              add: ["NET_ADMIN"]
+              drop:
+              - all
+              add:
+              - NET_ADMIN  # required by frontend and bird
+              - NET_BIND_SERVICE  # required by bird to support binding to classic BGP port number 173
+              - DAC_OVERRIDE  # required by debug tools netstat, ss
+              - NET_RAW  # required by debug tools tcpdump, ping
+              - SYS_PTRACE  # required by debug tools netstat, ss to list process names/ids
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets
@@ -238,6 +255,9 @@ spec:
               readOnly: false
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
+      securityContext:
+        fsGroup: 2000
+        fsGroupChangePolicy: "OnRootMismatch"
       volumes:
         - name: spire-agent-socket
           hostPath:

--- a/config/manager/deployment/nsp.yaml
+++ b/config/manager/deployment/nsp.yaml
@@ -91,11 +91,21 @@ spec:
               mountPath: /tmp
               readOnly: false
           securityContext:
+            runAsNonRoot: true
             readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+              - all
+              add:
+              - DAC_OVERRIDE  # required by debug tools netstat, ss
+              - NET_RAW  # required by debug tool ping
+              - SYS_PTRACE  # required by debug tools netstat, ss to list process names/ids
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
-      securityContext: {}
+      securityContext:
+        fsGroup: 2000
+        fsGroupChangePolicy: "OnRootMismatch"
       terminationGracePeriodSeconds: 30
       volumes:
         - name: spire-agent-socket

--- a/config/manager/deployment/proxy.yaml
+++ b/config/manager/deployment/proxy.yaml
@@ -115,9 +115,19 @@ spec:
               mountPath: /tmp
               readOnly: false
           securityContext:
+            runAsNonRoot: true
             readOnlyRootFilesystem: true
             capabilities:
-              add: ["NET_ADMIN"]
+              drop:
+              - all
+              add:
+              - NET_ADMIN  # required by proxy
+              - DAC_OVERRIDE  # required by proxy to use nsm-socket and by debug tools netstat, ss
+              - NET_RAW  # required by debug tools tcpdump, ping
+              - SYS_PTRACE  # required by debug tools netstat, ss to list process names/ids
+      securityContext:
+        fsGroup: 2000
+        fsGroupChangePolicy: "OnRootMismatch"
       volumes:
         - name: spire-agent-socket
           hostPath:


### PR DESCRIPTION
Meridio images must contain a numeric user, and binaries must
have the necessary capabilities.

NSC and Remote VLAN NSE are not yet changed to run as non-root.

https://github.com/Nordix/Meridio/pull/244