### PR TITLE
Run VLAN NSE,NSC as non-root

### DIFF
--- a/config/manager/deployment/lb-fe.yaml
+++ b/config/manager/deployment/lb-fe.yaml
@@ -160,6 +160,17 @@ spec:
             - name: nsm-socket
               mountPath: /var/lib/networkservicemesh
               readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 10000
+            runAsGroup: 10000
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+              - all
+              add:
+              - DAC_OVERRIDE
+              - NET_RAW
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
         - name: fe

--- a/config/manager/deployment/nse-vlan.yaml
+++ b/config/manager/deployment/nse-vlan.yaml
@@ -104,7 +104,13 @@ spec:
               mountPath: /var/lib/networkservicemesh
               readOnly: false
           securityContext:
+            runAsNonRoot: true
+            runAsUser: 10000
+            runAsGroup: 10000
             readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+              - all
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
       volumes:


### PR DESCRIPTION
VLAN NSE does not require any changes or capabilities to run as non-root.

NSC requires CAP_DAC_OVERRIDE to write to nsm-sock, and optionally CAP_NET_RAW
to use ping from the container. (The Dockerfile must be changed accordingly.)

Meridio PR:
https://github.com/Nordix/Meridio/pull/250

Issue:
https://github.com/Nordix/Meridio/issues/15