### PR TITLE
PDB v1beta1 support (Kubernetes <= 1.20)

### DIFF
--- a/controllers/attractor/pdb.go
+++ b/controllers/attractor/pdb.go
@@ -1,26 +1,45 @@
+/*
+Copyright (c) 2022 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package attractor
 
 import (
 	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
 	common "github.com/nordix/meridio-operator/controllers/common"
 	policyv1 "k8s.io/api/policy/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type LoadBalancerPDB struct {
-	model     *policyv1.PodDisruptionBudget
-	attractor *meridiov1alpha1.Attractor
-	exec      *common.Executor
-	trench    *meridiov1alpha1.Trench
+	model      *policyv1.PodDisruptionBudget
+	attractor  *meridiov1alpha1.Attractor
+	exec       *common.Executor
+	trench     *meridiov1alpha1.Trench
+	pdbVersion string
 }
 
-func NewLoadBalancerPDB(e *common.Executor, attr *meridiov1alpha1.Attractor, t *meridiov1alpha1.Trench) (*LoadBalancerPDB, error) {
+func NewLoadBalancerPDB(e *common.Executor, attr *meridiov1alpha1.Attractor, t *meridiov1alpha1.Trench, pdbVersion string) (*LoadBalancerPDB, error) {
 	pdb := &LoadBalancerPDB{
-		attractor: attr,
-		exec:      e,
-		trench:    t,
+		attractor:  attr,
+		exec:       e,
+		trench:     t,
+		pdbVersion: pdbVersion,
 	}
 	err := pdb.getModel()
 	if err != nil {
@@ -62,7 +81,7 @@ func (i *LoadBalancerPDB) getReconciledDesiredStatus(pdb *policyv1.PodDisruption
 	return i.insertParameters(template)
 }
 
-func (i *LoadBalancerPDB) getCurrentStatus() (*policyv1.PodDisruptionBudget, error) {
+func (i *LoadBalancerPDB) getCurrentStatusV1() (*policyv1.PodDisruptionBudget, error) {
 	currentStatus := &policyv1.PodDisruptionBudget{}
 	selector := i.getSelector()
 	err := i.exec.GetObject(selector, currentStatus)
@@ -75,8 +94,30 @@ func (i *LoadBalancerPDB) getCurrentStatus() (*policyv1.PodDisruptionBudget, err
 	return currentStatus, nil
 }
 
+func (i *LoadBalancerPDB) getCurrentStatusV1Beta1() (*policyv1beta1.PodDisruptionBudget, error) {
+	currentStatus := &policyv1beta1.PodDisruptionBudget{}
+	selector := i.getSelector()
+	err := i.exec.GetObject(selector, currentStatus)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return currentStatus, nil
+}
+
 func (i *LoadBalancerPDB) getAction() error {
-	cs, err := i.getCurrentStatus()
+	if i.pdbVersion == policyv1beta1.SchemeGroupVersion.Version {
+		return i.getActionV1Beta1()
+	} else if i.pdbVersion == policyv1.SchemeGroupVersion.Version {
+		return i.getActionV1()
+	}
+	return nil
+}
+
+func (i *LoadBalancerPDB) getActionV1() error {
+	cs, err := i.getCurrentStatusV1()
 	if err != nil {
 		return err
 	}
@@ -90,6 +131,27 @@ func (i *LoadBalancerPDB) getAction() error {
 		ds := i.getReconciledDesiredStatus(cs)
 		if !equality.Semantic.DeepEqual(ds.Spec, cs.Spec) {
 			i.exec.AddUpdateAction(ds)
+		}
+	}
+	return nil
+}
+
+func (i *LoadBalancerPDB) getActionV1Beta1() error {
+	csV1Beta1, err := i.getCurrentStatusV1Beta1()
+	if err != nil {
+		return err
+	}
+	cs := common.PdbV1Beta1ToV1(csV1Beta1)
+	if cs == nil {
+		ds := i.getDesiredStatus()
+		if err != nil {
+			return err
+		}
+		i.exec.AddCreateAction(common.PdbV1ToV1Beta1(ds))
+	} else {
+		ds := i.getReconciledDesiredStatus(cs)
+		if !equality.Semantic.DeepEqual(ds.Spec, cs.Spec) {
+			i.exec.AddUpdateAction(common.PdbV1ToV1Beta1(ds))
 		}
 	}
 	return nil

--- a/controllers/common/version.go
+++ b/controllers/common/version.go
@@ -1,0 +1,59 @@
+/*
+Copyright (c) 2022 Nordix Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"reflect"
+
+	policyv1 "k8s.io/api/policy/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetPodDisruptionBudgetVersion(client client.Client) (string, error) {
+	t := reflect.TypeOf(&policyv1.PodDisruptionBudget{})
+	gk := schema.GroupKind{
+		Group: policyv1.GroupName,
+		Kind:  t.Elem().Name(),
+	}
+	gvk, err := client.RESTMapper().RESTMapping(gk)
+	if err != nil {
+		return "", err
+	}
+	return gvk.GroupVersionKind.Version, nil
+}
+
+func PdbV1Beta1ToV1(pdb *policyv1beta1.PodDisruptionBudget) *policyv1.PodDisruptionBudget {
+	if pdb == nil {
+		return nil
+	}
+	v1Pdb := &policyv1.PodDisruptionBudget{}
+	v1Pdb.ObjectMeta = pdb.ObjectMeta
+	v1Pdb.Spec = policyv1.PodDisruptionBudgetSpec(pdb.Spec)
+	return v1Pdb
+}
+
+func PdbV1ToV1Beta1(pdb *policyv1.PodDisruptionBudget) *policyv1beta1.PodDisruptionBudget {
+	if pdb == nil {
+		return nil
+	}
+	v1beta1Pdb := &policyv1beta1.PodDisruptionBudget{}
+	v1beta1Pdb.ObjectMeta = pdb.ObjectMeta
+	v1beta1Pdb.Spec = policyv1beta1.PodDisruptionBudgetSpec(pdb.Spec)
+	return v1beta1Pdb
+}

--- a/controllers/trench/trench_controller.go
+++ b/controllers/trench/trench_controller.go
@@ -23,7 +23,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -51,7 +50,6 @@ type TrenchReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=services,namespace=system,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=serviceaccounts,namespace=system,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=configmaps,namespace=system,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,namespace=system,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,namespace=system,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,namespace=system,verbs=get;list;watch;create;update;patch;delete
 
@@ -96,12 +94,10 @@ func (r *TrenchReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&meridiov1alpha1.Trench{}).
 		Owns(&corev1.Service{}).
-		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&rbacv1.Role{}).
 		Owns(&rbacv1.RoleBinding{}).
-		Owns(&appsv1.DaemonSet{}).
-		Owns(&policyv1.PodDisruptionBudget{}).
+		Owns(&appsv1.StatefulSet{}).
 		Watches(
 			&source.Kind{Type: &meridiov1alpha1.Attractor{}},
 			&handler.EnqueueRequestForOwner{OwnerType: &meridiov1alpha1.Trench{}, IsController: false},


### PR DESCRIPTION
## Description

* PDB V1 is not supported by Kubernetes <= 1.20
* The operator is now supporting PDB v1 + v1beta1
* v1 is the preferred version, v1beta1 is used if v1 is not available

## Issue link

/

## Checklist

- Purpose
    - [ ] Bug fix
    - [x] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No
