### PR TITLE
Fix for the ephemeral containers

### DIFF
--- a/controllers/attractor/lb-fe.go
+++ b/controllers/attractor/lb-fe.go
@@ -113,7 +113,10 @@ func (l *LoadBalancer) insertParameters(dep *appsv1.Deployment) *appsv1.Deployme
 
 	ret.Spec.Template.ObjectMeta.Labels["app"] = lbFeDeploymentName
 	ret.Spec.Template.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0].LabelSelector.MatchExpressions[0].Values[0] = lbFeDeploymentName
-	ret.Spec.Template.Spec.ImagePullSecrets = common.GetImagePullSecrets()
+	imagePullSecrets := common.GetImagePullSecrets()
+	if len(imagePullSecrets) > 0 {
+		ret.Spec.Template.Spec.ImagePullSecrets = imagePullSecrets
+	}
 
 	if ret.Spec.Template.Spec.InitContainers[0].Image == "" {
 		ret.Spec.Template.Spec.InitContainers[0].Image = fmt.Sprintf("%s/%s/%s:%s", common.Registry, common.Organization, common.BusyboxImage, common.BusyboxTag)

--- a/controllers/attractor/nse-vlan.go
+++ b/controllers/attractor/nse-vlan.go
@@ -76,7 +76,10 @@ func (i *NseDeployment) insertParameters(dep *appsv1.Deployment) *appsv1.Deploym
 	ret.Spec.Selector.MatchLabels["app"] = nseVLANDeploymentName
 	ret.Spec.Template.ObjectMeta.Labels["app"] = nseVLANDeploymentName
 
-	ret.Spec.Template.Spec.ImagePullSecrets = common.GetImagePullSecrets()
+	imagePullSecrets := common.GetImagePullSecrets()
+	if len(imagePullSecrets) > 0 {
+		ret.Spec.Template.Spec.ImagePullSecrets = imagePullSecrets
+	}
 
 	// check resource requirement annotation update, and save annotation into deployment for visibility
 	oa, _ := common.GetResourceRequirementAnnotation(&dep.ObjectMeta)

--- a/controllers/common/const.go
+++ b/controllers/common/const.go
@@ -163,8 +163,11 @@ func GetLogLevel() string {
 
 func GetImagePullSecrets() []corev1.LocalObjectReference {
 	secstr := os.Getenv(ImagePullSecretEnv)
-	secs := strings.Split(secstr, ",")
 	var pullSecs []corev1.LocalObjectReference
+	if len(secstr) == 0 {
+		return pullSecs
+	}
+	secs := strings.Split(secstr, ",")
 	for _, sec := range secs {
 		pullSecs = append(pullSecs, corev1.LocalObjectReference{
 			Name: strings.TrimSpace(sec),

--- a/controllers/conduit/proxy.go
+++ b/controllers/conduit/proxy.go
@@ -83,7 +83,10 @@ func (i *Proxy) insertParameters(init *appsv1.DaemonSet) *appsv1.DaemonSet {
 	ds.Spec.Selector.MatchLabels["app"] = proxyDeploymentName
 	ds.Spec.Template.ObjectMeta.Labels["app"] = proxyDeploymentName
 
-	ds.Spec.Template.Spec.ImagePullSecrets = common.GetImagePullSecrets()
+	imagePullSecrets := common.GetImagePullSecrets()
+	if len(imagePullSecrets) > 0 {
+		ds.Spec.Template.Spec.ImagePullSecrets = imagePullSecrets
+	}
 
 	// init container
 	if ds.Spec.Template.Spec.InitContainers[0].Image == "" {

--- a/controllers/trench/ipam.go
+++ b/controllers/trench/ipam.go
@@ -83,7 +83,10 @@ func (i *IpamStatefulSet) insertParameters(dep *appsv1.StatefulSet) *appsv1.Stat
 
 	ret.Spec.ServiceName = ipamStatefulSetName
 
-	ret.Spec.Template.Spec.ImagePullSecrets = common.GetImagePullSecrets()
+	imagePullSecrets := common.GetImagePullSecrets()
+	if len(imagePullSecrets) > 0 {
+		ret.Spec.Template.Spec.ImagePullSecrets = imagePullSecrets
+	}
 
 	// check resource requirement annotation update, and save annotation into deployment for visibility
 	oa, _ := common.GetResourceRequirementAnnotation(&dep.ObjectMeta)

--- a/controllers/trench/nsp.go
+++ b/controllers/trench/nsp.go
@@ -74,7 +74,10 @@ func (i *NspStatefulSet) insertParameters(init *appsv1.StatefulSet) *appsv1.Stat
 	ret.Spec.Template.ObjectMeta.Labels["app"] = nspStatefulSetName
 	ret.Spec.Template.Spec.ServiceAccountName = common.ServiceAccountName(i.trench)
 
-	ret.Spec.Template.Spec.ImagePullSecrets = common.GetImagePullSecrets()
+	imagePullSecrets := common.GetImagePullSecrets()
+	if len(imagePullSecrets) > 0 {
+		ret.Spec.Template.Spec.ImagePullSecrets = imagePullSecrets
+	}
 
 	// check resource requirement annotation update, and save annotation into deployment for visibility
 	oa, _ := common.GetResourceRequirementAnnotation(&init.ObjectMeta)


### PR DESCRIPTION
## Description

* If the ImagePullSecrets property was empty and kubectl debug was used to inject an ephemeral container, the following error was returned: `error: error creating patch to add debug container: map: map[] does not contain declared merge key: name`

https://github.com/kubernetes/kubernetes/issues/98963

## Issue link

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No