### PR TITLE
Update capabilities according to NSM v1.5

### DIFF
--- a/config/manager/deployment/ipam.yaml
+++ b/config/manager/deployment/ipam.yaml
@@ -111,9 +111,9 @@ spec:
               drop:
               - all
               add:
-              - DAC_OVERRIDE  # required by debug tools netstat, ss
-              - NET_RAW  # required by debug tool ping
-              - SYS_PTRACE  # required by debug tools netstat, ss to list process names/ids
+              - DAC_OVERRIDE  # required by debug tools (netstat, ss)
+              - NET_RAW  # required by debug tool (ping)
+              - SYS_PTRACE  # required by debug tools (netstat, ss to list process names/ids)
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/config/manager/deployment/lb-fe.yaml
+++ b/config/manager/deployment/lb-fe.yaml
@@ -124,11 +124,11 @@ spec:
               - all
               add:
               - NET_ADMIN  # required by load-balancer and nfqlb
-              - DAC_OVERRIDE  # required by load-balancer to use nsm-socket and by debug tools netstat, ss
               - IPC_LOCK  # required by nfqlb because of shared-mem
               - IPC_OWNER  # required by nfqlb because of shared-mem
-              - NET_RAW  # required by debug tools tcpdump, ping
-              - SYS_PTRACE  # required by debug tools netstat, ss to list process names/ids
+              - DAC_OVERRIDE  # required by debug tools (netstat, ss)
+              - NET_RAW  # required by debug tools (tcpdump, ping)
+              - SYS_PTRACE  # required by debug tools (netstat, ss to list process names/ids)
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
         - name: nsc
@@ -168,9 +168,6 @@ spec:
             capabilities:
               drop:
               - all
-              add:
-              - DAC_OVERRIDE
-              - NET_RAW
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
         - name: fe
@@ -245,9 +242,9 @@ spec:
               add:
               - NET_ADMIN  # required by frontend and bird
               - NET_BIND_SERVICE  # required by bird to support binding to classic BGP port number 173
-              - DAC_OVERRIDE  # required by debug tools netstat, ss
-              - NET_RAW  # required by debug tools tcpdump, ping
-              - SYS_PTRACE  # required by debug tools netstat, ss to list process names/ids
+              - DAC_OVERRIDE  # required by debug tools (netstat, ss)
+              - NET_RAW  # required by debug tools (tcpdump, ping)
+              - SYS_PTRACE  # required by debug tools (netstat, ss to list process names/ids)
           volumeMounts:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets

--- a/config/manager/deployment/nsp.yaml
+++ b/config/manager/deployment/nsp.yaml
@@ -97,9 +97,9 @@ spec:
               drop:
               - all
               add:
-              - DAC_OVERRIDE  # required by debug tools netstat, ss
-              - NET_RAW  # required by debug tool ping
-              - SYS_PTRACE  # required by debug tools netstat, ss to list process names/ids
+              - DAC_OVERRIDE  # required by debug tools (netstat, ss)
+              - NET_RAW  # required by debug tool (ping)
+              - SYS_PTRACE  # required by debug tools (netstat, ss to list process names/ids)
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/config/manager/deployment/proxy.yaml
+++ b/config/manager/deployment/proxy.yaml
@@ -122,9 +122,9 @@ spec:
               - all
               add:
               - NET_ADMIN  # required by proxy
-              - DAC_OVERRIDE  # required by proxy to use nsm-socket and by debug tools netstat, ss
-              - NET_RAW  # required by debug tools tcpdump, ping
-              - SYS_PTRACE  # required by debug tools netstat, ss to list process names/ids
+              - DAC_OVERRIDE  # required by debug tools (netstat, ss)
+              - NET_RAW  # required by debug tools (tcpdump, ping)
+              - SYS_PTRACE  # required by debug tools (netstat, ss to list process names/ids)
       securityContext:
         fsGroup: 2000
         fsGroupChangePolicy: "OnRootMismatch"


### PR DESCRIPTION
## Description
CAP_DAC_OVERRIDE no longer required to interact with NSM v1.5,
meaning less mandatory capabilities to run as non-root.

The images must be updated as well. Also, deploying Meridio on
older NSM versions will NOT work.

## Issue link
https://github.com/Nordix/Meridio/issues/263

## Checklist

- Purpose
    - [ ] Bug fix
    - [x] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [x] Yes (description required)
      Deploying Meridio on older NSM versions will NOT work.
    - [ ] No