### PR TITLE
Remove hostport from the NSE-VLAN container

### DIFF
--- a/config/manager/deployment/nse-vlan.yaml
+++ b/config/manager/deployment/nse-vlan.yaml
@@ -72,7 +72,6 @@ spec:
             successThreshold: 1
           ports:  # will be filled by operator if not specified
             - containerPort: 5003
-              hostPort: 5003
           env:
             - name: SPIFFE_ENDPOINT_SOCKET
               value: unix:///run/spire/sockets/agent.sock

--- a/controllers/attractor/nse-vlan.go
+++ b/controllers/attractor/nse-vlan.go
@@ -106,9 +106,6 @@ func (i *NseDeployment) insertParameters(dep *appsv1.Deployment) *appsv1.Deploym
 				container.LivenessProbe = common.GetProbe(common.LivenessTimer,
 					common.GetProbeCommand(true, fmt.Sprintf(":%d", common.VlanNsePort), ""))
 			}
-			if len(container.Ports) == 0 {
-				container.Ports = append([]corev1.ContainerPort{}, corev1.ContainerPort{HostPort: common.VlanNsePort, ContainerPort: common.VlanNsePort})
-			}
 			container.Env = i.getEnvVars(container.Env)
 			// set resource requirements for container (if not found, then values from model
 			// are kept even upon updates, as getReconciledDesiredStatus() overwrites containers)


### PR DESCRIPTION
## Description

This hostport is not needed. If we have it, it will limit the number of trench we could have in a kubernetes. The max number of trench will be equal to the number of kubernetes worker node.

## Issue link

https://github.com/Nordix/Meridio/pull/273

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No