### PR TITLE
TLS min version set to 1.2 for the webhook server

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/faisal-memon/sviddisk"
 	meridiov1alpha1 "github.com/nordix/meridio-operator/api/v1alpha1"
@@ -158,6 +159,9 @@ func main() {
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "132659e3.nordix.org",
 		Namespace:              namespace,
+		WebhookServer: &webhook.Server{
+			TLSMinVersion: "1.2",
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
## Description

Controller-runtime sets the min version for TLS on the webhook to 1.0 by default.

## Issue link

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No