### PR TITLE
Set automountServiceAccountToken to false

### DIFF
--- a/config/templates/charts/meridio/deployment/ipam.yaml
+++ b/config/templates/charts/meridio/deployment/ipam.yaml
@@ -19,6 +19,7 @@ spec:
         app: ipam
         "spiffe.io/spiffe-id": "true"
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: ipam
           image: {{ .Values.registry }}/{{ .Values.organization }}/{{ .Values.ipam.image }}:{{ .Values.version }}

--- a/config/templates/charts/meridio/deployment/lb-fe.yaml
+++ b/config/templates/charts/meridio/deployment/lb-fe.yaml
@@ -44,6 +44,7 @@ spec:
           args:  # to be filled by operator according to trench
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
+      automountServiceAccountToken: false
       containers:
         - name: load-balancer
           image: {{ .Values.registry }}/{{ .Values.organization }}/{{ .Values.loadBalancer.image }}:{{ .Values.version }}

--- a/config/templates/charts/meridio/deployment/nse-vlan.yaml
+++ b/config/templates/charts/meridio/deployment/nse-vlan.yaml
@@ -24,6 +24,7 @@ spec:
         app: nse-vlan
         "spiffe.io/spiffe-id": "true"
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: nse
           image: {{ .Values.registry }}/{{ .Values.nsm.organization }}/{{ .Values.vlanNSE.image }}:{{ .Values.nsm.version }}

--- a/config/templates/charts/meridio/deployment/proxy.yaml
+++ b/config/templates/charts/meridio/deployment/proxy.yaml
@@ -24,6 +24,7 @@ spec:
             privileged: true
           command: ["/bin/sh"]
           args:  # to be filled by operator according to the Trench
+      automountServiceAccountToken: false
       containers:
         - name: proxy
           image: {{ .Values.registry }}/{{ .Values.organization }}/{{ .Values.proxy.image }}:{{ .Values.version }}


### PR DESCRIPTION
## Description

Set to false on stateless-lb-frontend, nse-vlan, ipam and proxy

## Issue link

## Checklist

- Purpose
    - [ ] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No