### PR TITLE
templates; remove nsm-sock hostPath volume from Remote VLAN NSE

### DIFF
--- a/config/templates/charts/meridio/deployment/nse-vlan.yaml
+++ b/config/templates/charts/meridio/deployment/nse-vlan.yaml
@@ -99,9 +99,6 @@ spec:
             - name: spire-agent-socket
               mountPath: /run/spire/sockets
               readOnly: true
-            - name: nsm-socket
-              mountPath: /var/lib/networkservicemesh
-              readOnly: false
           securityContext:
             runAsNonRoot: true
             runAsUser: 10000
@@ -117,7 +114,3 @@ spec:
           hostPath:
             path: /run/spire/sockets
             type: Directory
-        - name: nsm-socket
-          hostPath:
-            path: /var/lib/networkservicemesh
-            type: DirectoryOrCreate


### PR DESCRIPTION
## Description
Remove nsm-sock hostPath volume from Remote VLAN NSE, as this NSE does not need to
contact NSMgr.

## Issue link
NA

## Checklist

- Purpose
    - [x] Bug fix
    - [ ] New functionality
    - [ ] Documentation
    - [ ] Refactoring
    - [ ] CI
- Test
    - [ ] Unit test
    - [ ] E2E Test
    - [x] Tested manually
- Introduce a breaking change
    - [ ] Yes (description required)
    - [x] No